### PR TITLE
feat: support struct pointer fields as optional parameter groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,16 @@ CLI args > Environment vars > Root config file > Substruct config files > Defaul
 - Explicit `name:"..."` and `env:"..."` tags also get prefixed inside named fields
 - This prevents collisions when the same struct is used in multiple named fields
 
+### Struct Pointer Fields (Optional Parameter Groups)
+- `DB *DBConfig` — pointer struct fields act as optional parameter groups
+- Nil struct pointers are preallocated during init, so their child flags are registered
+- After parsing, if no field within the struct was set (CLI, env, or config), the pointer is nil'd back
+- `p.DB == nil` means nothing in the group was configured; `p.DB != nil` means at least one field was set
+- Defaults alone don't keep the struct alive — only explicit user input does
+- Nested pointer structs work: `Outer *OuterConfig` where OuterConfig has `Inner *InnerConfig`
+- Config file key-presence detection handles zero-value and same-as-default config entries (JSON only)
+- Works with all features: validation tags, custom validators, alternatives, HookContext access
+
 ## Testing
 
 Run all tests:

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -412,7 +412,8 @@ func SubCmds(cmds ...CmdIfc) []*cobra.Command {
 // CLI and env var values still take precedence when used in PreValidateFunc.
 // If unmarshalFunc is nil, defaults to json.Unmarshal.
 func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte, any) error) error {
-	return loadConfigFileInto(filePath, target, unmarshalFunc)
+	_, err := loadConfigFileInto(filePath, target, unmarshalFunc)
+	return err
 }
 
 // configFormats maps file extensions to unmarshal functions.
@@ -447,13 +448,13 @@ func ConfigFormatExtensions() []string {
 //  1. Explicit unmarshalFunc parameter (from Cmd.ConfigUnmarshal)
 //  2. Registered format based on file extension
 //  3. json.Unmarshal (default fallback)
-func loadConfigFileInto(filePath string, target any, unmarshalFunc func([]byte, any) error) error {
+func loadConfigFileInto(filePath string, target any, unmarshalFunc func([]byte, any) error) ([]byte, error) {
 	if filePath == "" {
-		return nil
+		return nil, nil
 	}
 	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read config file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to read config file %s: %w", filePath, err)
 	}
 	if unmarshalFunc == nil {
 		// Look up by file extension
@@ -465,9 +466,9 @@ func loadConfigFileInto(filePath string, target any, unmarshalFunc func([]byte, 
 		}
 	}
 	if err := unmarshalFunc(fileContents, target); err != nil {
-		return fmt.Errorf("failed to unmarshal config file %s: %w", filePath, err)
+		return nil, fmt.Errorf("failed to unmarshal config file %s: %w", filePath, err)
 	}
-	return nil
+	return fileContents, nil
 }
 
 // UnMarshalFromFileParam reads a file path from a parameter and unmarshals its contents into a target struct.

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -84,9 +84,15 @@ type Cmd struct {
 
 // HasValue checks if a parameter has a value from any source.
 // Returns true if the parameter was set by environment variable, command line,
-// default value, or programmatic injection.
+// config file, default value, or programmatic injection.
 func HasValue(f Param) bool {
-	return f.wasSetByEnv() || f.wasSetOnCli() || f.hasDefaultValue() || f.wasSetByInject()
+	if f.wasSetByEnv() || f.wasSetOnCli() || f.hasDefaultValue() || f.wasSetByInject() {
+		return true
+	}
+	if pm, ok := f.(*paramMeta); ok && pm.setByConfig {
+		return true
+	}
+	return false
 }
 
 // ParamEnricher is a function type that can add or modify parameter metadata.

--- a/pkg/boa/coverage_test.go
+++ b/pkg/boa/coverage_test.go
@@ -1870,7 +1870,7 @@ func TestLoadConfigFileExtensionLookup(t *testing.T) {
 	_ = tmpFile.Close()
 
 	var cfg Config
-	err := loadConfigFileInto(tmpFile.Name(), &cfg, nil)
+	_, err := loadConfigFileInto(tmpFile.Name(), &cfg, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -197,6 +197,10 @@ type processingContext struct {
 	// PreallocatedPtrs tracks struct pointer fields that were nil and got preallocated.
 	// Ordered depth-first (innermost first) so cleanup processes leaves before parents.
 	PreallocatedPtrs []preallocatedPtrInfo
+	// ConfigPresentPtrs tracks preallocated struct pointers that were explicitly
+	// mentioned in a config file (even if no child fields were set, e.g., "DB": {}).
+	// These survive cleanup regardless of whether individual fields were set.
+	ConfigPresentPtrs map[uintptr]bool
 }
 
 // preallocateStructPtrs walks the struct tree and allocates any nil struct pointer fields,
@@ -249,8 +253,15 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 		structPtr := info.ptrField.Interface()
 		anySet := false
 
+		// Check if this struct was explicitly mentioned in a config file
+		if ctx.ConfigPresentPtrs[reflect.ValueOf(structPtr).Pointer()] {
+			anySet = true
+		}
+
 		// Walk the struct's fields and check if any mirror was explicitly set
-		collectAndCheck(ctx, structPtr, &anySet)
+		if !anySet {
+			collectAndCheck(ctx, structPtr, &anySet)
+		}
 
 		if !anySet {
 			// Check if any nested struct pointer survived cleanup (is still non-nil).
@@ -280,22 +291,58 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 // even if the values are zero or match the defaults.
 //
 // It unmarshals the raw bytes into map[string]json.RawMessage to get the set of
-// top-level keys, then matches them against struct field names. For nested structs,
-// it recurses into the sub-maps.
+// top-level keys, then matches them against struct field names using the same
+// case-insensitive logic as encoding/json. For nested structs, it recurses into
+// the sub-maps.
 //
-// This only works for JSON-compatible unmarshalers. For custom formats, the caller
-// should fall back to a snapshot-based comparison or implement their own detection.
-func markConfigKeysPresent(ctx *processingContext, target any, rawData []byte) {
+// Returns true if key-presence detection succeeded (JSON-compatible data).
+// Returns false for non-JSON data so the caller can fall back to snapshot comparison.
+func markConfigKeysPresent(ctx *processingContext, target any, rawData []byte) bool {
 	if len(ctx.PreallocatedPtrs) == 0 || len(rawData) == 0 {
-		return
+		return false
 	}
 	// Probe the raw data for top-level keys
 	var topLevel map[string]json.RawMessage
 	if err := json.Unmarshal(rawData, &topLevel); err != nil {
-		return // not JSON-compatible; skip key detection
+		return false // not JSON-compatible; caller should use snapshot fallback
 	}
 	// Walk the target struct type and match keys against preallocated struct ptrs
 	markConfigKeysPresentInStruct(ctx, target, topLevel)
+	return true
+}
+
+// jsonFieldKey returns the key that encoding/json would use for a struct field.
+// If a json tag is present, use its name. Otherwise, use the Go field name.
+func jsonFieldKey(field reflect.StructField) string {
+	if tag := field.Tag.Get("json"); tag != "" {
+		parts := strings.SplitN(tag, ",", 2)
+		if parts[0] != "" && parts[0] != "-" {
+			return parts[0]
+		}
+		if parts[0] == "-" {
+			return "" // explicitly skipped
+		}
+	}
+	return field.Name
+}
+
+// jsonKeyLookup does a case-insensitive key lookup matching encoding/json behavior:
+// exact match first, then case-insensitive fallback.
+func jsonKeyLookup(keys map[string]json.RawMessage, target string) (json.RawMessage, bool) {
+	if target == "" {
+		return nil, false
+	}
+	// Exact match first (fast path)
+	if v, ok := keys[target]; ok {
+		return v, true
+	}
+	// Case-insensitive fallback (matches encoding/json behavior)
+	for k, v := range keys {
+		if strings.EqualFold(k, target) {
+			return v, true
+		}
+	}
+	return nil, false
 }
 
 func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]json.RawMessage) {
@@ -306,25 +353,20 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 		if isBoaIgnored(field) {
 			continue
 		}
-		// Determine the JSON key for this field
-		jsonKey := field.Name
-		if tag := field.Tag.Get("json"); tag != "" {
-			parts := strings.SplitN(tag, ",", 2)
-			if parts[0] != "" && parts[0] != "-" {
-				jsonKey = parts[0]
-			}
-		}
-		rawVal, keyPresent := keys[jsonKey]
+		jsonKey := jsonFieldKey(field)
+		rawVal, keyPresent := jsonKeyLookup(keys, jsonKey)
 		if !keyPresent {
 			continue
 		}
 		fieldVal := val.Field(i)
-		// If this is a struct pointer field and it's preallocated (non-nil), mark it
+		// If this is a struct pointer field and it's preallocated (non-nil)
 		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) && !fieldVal.IsNil() {
-			markAllMirrorsInStruct(ctx, fieldVal.Interface())
-			// Recurse into the sub-object to handle nested preallocated ptrs
+			// The config mentioned this struct — mark it as present so the
+			// pointer survives cleanup, even if the object is empty `{}`.
+			// Individual fields only get setByConfig if they appear as keys.
+			markStructPtrPresentByConfig(ctx, fieldVal.Interface())
 			var subKeys map[string]json.RawMessage
-			if json.Unmarshal(rawVal, &subKeys) == nil {
+			if json.Unmarshal(rawVal, &subKeys) == nil && len(subKeys) > 0 {
 				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subKeys)
 			}
 			continue
@@ -337,7 +379,59 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 			}
 			continue
 		}
+		// Leaf field present in config — mark its mirror
+		if isSupportedType(field.Type) {
+			addr := fieldVal.Addr().UnsafePointer()
+			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+				if pm, isPM := mirror.(*paramMeta); isPM {
+					pm.setByConfig = true
+				}
+			}
+		}
 	}
+}
+
+// snapshotPreallocatedStructs takes a deep copy of each preallocated struct's value.
+// Used as fallback for non-JSON config formats where key-presence detection can't work.
+func snapshotPreallocatedStructs(ctx *processingContext) []reflect.Value {
+	snapshots := make([]reflect.Value, len(ctx.PreallocatedPtrs))
+	for i, info := range ctx.PreallocatedPtrs {
+		if info.ptrField.IsNil() {
+			continue
+		}
+		orig := info.ptrField.Elem()
+		cp := reflect.New(orig.Type()).Elem()
+		cp.Set(orig)
+		snapshots[i] = cp
+	}
+	return snapshots
+}
+
+// markConfigChangedStructs compares preallocated struct values against pre-config
+// snapshots. If any struct changed, marks all its mirrors as setByConfig.
+// This is the fallback for non-JSON formats where key-presence detection can't work.
+func markConfigChangedStructs(ctx *processingContext, snapshots []reflect.Value) {
+	for i, info := range ctx.PreallocatedPtrs {
+		if info.ptrField.IsNil() || !snapshots[i].IsValid() {
+			continue
+		}
+		current := info.ptrField.Elem()
+		if !reflect.DeepEqual(current.Interface(), snapshots[i].Interface()) {
+			markAllMirrorsInStruct(ctx, info.ptrField.Interface())
+		}
+	}
+}
+
+// markStructPtrPresentByConfig records that a preallocated struct pointer was
+// explicitly mentioned in a config file. This ensures the pointer survives
+// cleanup even if no individual child fields were set (e.g., "DB": {}).
+// Individual field HasValue is not affected — only cleanup is.
+func markStructPtrPresentByConfig(ctx *processingContext, structPtr any) {
+	addr := reflect.ValueOf(structPtr).Pointer()
+	if ctx.ConfigPresentPtrs == nil {
+		ctx.ConfigPresentPtrs = make(map[uintptr]bool)
+	}
+	ctx.ConfigPresentPtrs[addr] = true
 }
 
 // markAllMirrorsInStruct marks mirrors in this struct as set by config.
@@ -1562,6 +1656,13 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 
 			syncMirrors(ctx)
 
+			// Snapshot preallocated structs before config loading. Used as fallback
+			// for non-JSON formats where key-presence detection can't work.
+			var preConfigSnapshots []reflect.Value
+			if len(ctx.PreallocatedPtrs) > 0 {
+				preConfigSnapshots = snapshotPreallocatedStructs(ctx)
+			}
+
 			// Auto-load config files tagged with configfile:"true".
 			// Substruct configs load first, root config loads last (root overrides inner).
 			// Priority: CLI > env > root config > substruct config > defaults
@@ -1617,8 +1718,18 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// Probe raw config data for key presence to detect which preallocated
 			// struct pointers were mentioned in config files. This detects writes
 			// even when the value equals Go's zero value or the field's default.
+			// For non-JSON formats, fall back to snapshot comparison.
+			allDetected := true
 			for _, cr := range configResults {
-				markConfigKeysPresent(ctx, cr.target, cr.rawData)
+				if !markConfigKeysPresent(ctx, cr.target, cr.rawData) {
+					allDetected = false
+				}
+			}
+			if !allDetected && preConfigSnapshots != nil {
+				// Non-JSON config format: fall back to comparing struct values
+				// before and after config loading. This catches changed values
+				// but can't detect zero-value or same-as-default writes.
+				markConfigChangedStructs(ctx, preConfigSnapshots)
 			}
 
 			// Clean up preallocated struct pointers that had no fields set.

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -2,6 +2,7 @@ package boa
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -173,6 +174,14 @@ type configFileEntry struct {
 	target any   // pointer to the struct to unmarshal into
 }
 
+// preallocatedPtrInfo tracks a struct pointer field that was nil and got preallocated
+// so that traverse could discover and register its child fields as CLI flags.
+// After all value sources are applied (CLI, env, config), the pointer is nil'd back
+// if none of its fields were explicitly set.
+type preallocatedPtrInfo struct {
+	ptrField reflect.Value // the pointer field in the parent struct (e.g., *DBConfig)
+}
+
 type processingContext struct {
 	context.Context
 	RawAddrToMirror map[unsafe.Pointer]Param
@@ -185,6 +194,258 @@ type processingContext struct {
 	// ConfigFiles tracks all configfile:"true" fields and their target structs.
 	// Ordered: substruct entries first, root entry last (so root overrides inner).
 	ConfigFiles []configFileEntry
+	// PreallocatedPtrs tracks struct pointer fields that were nil and got preallocated.
+	// Ordered depth-first (innermost first) so cleanup processes leaves before parents.
+	PreallocatedPtrs []preallocatedPtrInfo
+}
+
+// preallocateStructPtrs walks the struct tree and allocates any nil struct pointer fields,
+// tracking them in ctx.PreallocatedPtrs so they can be nil'd back after parsing if unused.
+// This must be called before the first traverse so that traverse discovers the child fields.
+// The list is built depth-first (innermost first) for correct cleanup ordering.
+func preallocateStructPtrs(ctx *processingContext, structPtr any) {
+	val := reflect.ValueOf(structPtr).Elem()
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if isBoaIgnored(field) {
+			continue
+		}
+		// Recurse into non-pointer structs (they're always present)
+		if field.Type.Kind() == reflect.Struct && !isSupportedType(field.Type) {
+			preallocateStructPtrs(ctx, val.Field(i).Addr().Interface())
+			continue
+		}
+		// Preallocate nil struct pointer fields
+		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) {
+			fieldVal := val.Field(i)
+			if fieldVal.IsNil() {
+				fieldVal.Set(reflect.New(field.Type.Elem()))
+				// Recurse into the newly allocated struct (inner pointers first)
+				preallocateStructPtrs(ctx, fieldVal.Interface())
+				// Append after recursion so innermost entries come first
+				ctx.PreallocatedPtrs = append(ctx.PreallocatedPtrs, preallocatedPtrInfo{
+					ptrField: fieldVal,
+				})
+			} else {
+				// Already non-nil (user pre-initialized) — still recurse for nested nil ptrs
+				preallocateStructPtrs(ctx, fieldVal.Interface())
+			}
+			continue
+		}
+	}
+}
+
+// cleanupPreallocatedPtrs nils back any preallocated struct pointers whose fields
+// were never explicitly set (via CLI, env, or config injection). Processes innermost
+// first so that nested struct pointers are cleaned before their parents.
+func cleanupPreallocatedPtrs(ctx *processingContext) {
+	for _, info := range ctx.PreallocatedPtrs {
+		if info.ptrField.IsNil() {
+			// Already cleaned up (e.g., parent was nil'd in a previous iteration)
+			continue
+		}
+
+		structPtr := info.ptrField.Interface()
+		anySet := false
+
+		// Walk the struct's fields and check if any mirror was explicitly set
+		collectAndCheck(ctx, structPtr, &anySet)
+
+		if !anySet {
+			// Check if any nested struct pointer survived cleanup (is still non-nil).
+			// This handles the case where a deeply nested field was set, which keeps
+			// the nested ptr alive — the parent should also survive.
+			structVal := reflect.ValueOf(structPtr).Elem()
+			for i := 0; i < structVal.NumField(); i++ {
+				f := structVal.Field(i)
+				if f.Kind() == reflect.Ptr && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+					anySet = true
+					break
+				}
+			}
+		}
+
+		if !anySet {
+			// Remove mirrors for all fields within this struct
+			removeMirrorsForStruct(ctx, structPtr)
+			// Nil the pointer
+			info.ptrField.Set(reflect.Zero(info.ptrField.Type()))
+		}
+	}
+}
+
+// markConfigKeysPresent probes the raw config file data for key presence to detect
+// which preallocated struct pointer fields were explicitly mentioned in the config,
+// even if the values are zero or match the defaults.
+//
+// It unmarshals the raw bytes into map[string]json.RawMessage to get the set of
+// top-level keys, then matches them against struct field names. For nested structs,
+// it recurses into the sub-maps.
+//
+// This only works for JSON-compatible unmarshalers. For custom formats, the caller
+// should fall back to a snapshot-based comparison or implement their own detection.
+func markConfigKeysPresent(ctx *processingContext, target any, rawData []byte) {
+	if len(ctx.PreallocatedPtrs) == 0 || len(rawData) == 0 {
+		return
+	}
+	// Probe the raw data for top-level keys
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(rawData, &topLevel); err != nil {
+		return // not JSON-compatible; skip key detection
+	}
+	// Walk the target struct type and match keys against preallocated struct ptrs
+	markConfigKeysPresentInStruct(ctx, target, topLevel)
+}
+
+func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]json.RawMessage) {
+	val := reflect.ValueOf(structPtr).Elem()
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if isBoaIgnored(field) {
+			continue
+		}
+		// Determine the JSON key for this field
+		jsonKey := field.Name
+		if tag := field.Tag.Get("json"); tag != "" {
+			parts := strings.SplitN(tag, ",", 2)
+			if parts[0] != "" && parts[0] != "-" {
+				jsonKey = parts[0]
+			}
+		}
+		rawVal, keyPresent := keys[jsonKey]
+		if !keyPresent {
+			continue
+		}
+		fieldVal := val.Field(i)
+		// If this is a struct pointer field and it's preallocated (non-nil), mark it
+		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) && !fieldVal.IsNil() {
+			markAllMirrorsInStruct(ctx, fieldVal.Interface())
+			// Recurse into the sub-object to handle nested preallocated ptrs
+			var subKeys map[string]json.RawMessage
+			if json.Unmarshal(rawVal, &subKeys) == nil {
+				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subKeys)
+			}
+			continue
+		}
+		// If this is a non-pointer struct, recurse
+		if field.Type.Kind() == reflect.Struct && !isSupportedType(field.Type) {
+			var subKeys map[string]json.RawMessage
+			if json.Unmarshal(rawVal, &subKeys) == nil {
+				markConfigKeysPresentInStruct(ctx, fieldVal.Addr().Interface(), subKeys)
+			}
+			continue
+		}
+	}
+}
+
+// markAllMirrorsInStruct marks mirrors in this struct as set by config.
+// It recurses into non-pointer structs but STOPS at pointer-to-struct boundaries.
+// Pointer-to-struct fields are handled by key-presence recursion in
+// markConfigKeysPresentInStruct, which only marks nested ptr structs if the
+// config data actually mentions them.
+func markAllMirrorsInStruct(ctx *processingContext, structPtr any) {
+	val := reflect.ValueOf(structPtr).Elem()
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if isBoaIgnored(field) {
+			continue
+		}
+		fieldVal := val.Field(i)
+		if isSupportedType(field.Type) {
+			addr := fieldVal.Addr().UnsafePointer()
+			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+				if pm, isPM := mirror.(*paramMeta); isPM {
+					pm.setByConfig = true
+				}
+			}
+			continue
+		}
+		if field.Type.Kind() == reflect.Struct {
+			markAllMirrorsInStruct(ctx, fieldVal.Addr().Interface())
+			continue
+		}
+		// Do NOT recurse into pointer-to-struct fields here.
+		// Key-presence detection handles them.
+	}
+}
+
+// collectAndCheck walks a struct's fields and checks if any mirror was explicitly set
+// by the user (CLI, env var, or config file). Default values alone don't count.
+func collectAndCheck(ctx *processingContext, structPtr any, anySet *bool) {
+	val := reflect.ValueOf(structPtr).Elem()
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		if *anySet {
+			return
+		}
+		field := typ.Field(i)
+		if isBoaIgnored(field) {
+			continue
+		}
+		fieldVal := val.Field(i)
+		if isSupportedType(field.Type) {
+			addr := fieldVal.Addr().UnsafePointer()
+			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+				pm, isPM := mirror.(*paramMeta)
+				if mirror.wasSetOnCli() || mirror.wasSetByEnv() {
+					*anySet = true
+					return
+				}
+				if isPM && pm.setByConfig {
+					*anySet = true
+					return
+				}
+			}
+			continue
+		}
+		// Recurse into non-pointer structs
+		if field.Type.Kind() == reflect.Struct {
+			collectAndCheck(ctx, fieldVal.Addr().Interface(), anySet)
+			continue
+		}
+		// Recurse into non-nil pointer structs
+		if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
+			collectAndCheck(ctx, fieldVal.Interface(), anySet)
+		}
+	}
+}
+
+// removeMirrorsForStruct removes all mirrors belonging to fields within the given struct
+// from the processing context, preventing dangling unsafe pointers after the struct is nil'd.
+func removeMirrorsForStruct(ctx *processingContext, structPtr any) {
+	val := reflect.ValueOf(structPtr).Elem()
+	typ := val.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if isBoaIgnored(field) {
+			continue
+		}
+		fieldVal := val.Field(i)
+		if isSupportedType(field.Type) {
+			addr := fieldVal.Addr().UnsafePointer()
+			delete(ctx.RawAddrToMirror, addr)
+			// Remove from RawAddresses slice
+			for j, a := range ctx.RawAddresses {
+				if a == addr {
+					ctx.RawAddresses = append(ctx.RawAddresses[:j], ctx.RawAddresses[j+1:]...)
+					break
+				}
+			}
+			continue
+		}
+		// Recurse into non-pointer structs
+		if field.Type.Kind() == reflect.Struct {
+			removeMirrorsForStruct(ctx, fieldVal.Addr().Interface())
+			continue
+		}
+		// Recurse into non-nil pointer structs
+		if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
+			removeMirrorsForStruct(ctx, fieldVal.Interface())
+		}
+	}
 }
 
 func parseEnv(ctx *processingContext, structPtr any) error {
@@ -940,6 +1201,13 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 		RawAddresses:    []unsafe.Pointer{},
 	}
 
+	// Preallocate nil struct pointer fields so traverse can discover their children.
+	// This must happen before the first traverse and before init hooks so users can
+	// access fields like &params.DB.Port in InitFunc/InitFuncCtx.
+	if b.Params != nil {
+		preallocateStructPtrs(ctx, b.Params)
+	}
+
 	// build mirrors
 	if b.Params != nil {
 		_ = traverse(ctx, b.Params, nil, func(innerParams any) error {
@@ -1297,6 +1565,16 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// Auto-load config files tagged with configfile:"true".
 			// Substruct configs load first, root config loads last (root overrides inner).
 			// Priority: CLI > env > root config > substruct config > defaults
+			//
+			// We collect (target, rawData) pairs so that after loading we can probe
+			// the raw bytes for key presence — this lets us detect config-file writes
+			// even when the value equals Go's zero value or the field's default.
+			type configLoadResult struct {
+				target  any
+				rawData []byte
+			}
+			var configResults []configLoadResult
+
 			if len(ctx.ConfigFiles) > 0 {
 				// Separate root and substruct entries
 				var subEntries, rootEntries []configFileEntry
@@ -1312,9 +1590,11 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 					if entry.mirror.HasValue() {
 						filePath := *(entry.mirror.valuePtrF().(*string))
 						if filePath != "" {
-							if err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal); err != nil {
+							rawData, err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal)
+							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
+							configResults = append(configResults, configLoadResult{target: entry.target, rawData: rawData})
 						}
 					}
 				}
@@ -1323,13 +1603,29 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 					if entry.mirror.HasValue() {
 						filePath := *(entry.mirror.valuePtrF().(*string))
 						if filePath != "" {
-							if err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal); err != nil {
+							rawData, err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal)
+							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
+							configResults = append(configResults, configLoadResult{target: entry.target, rawData: rawData})
 						}
 					}
 				}
 				syncMirrors(ctx)
+			}
+
+			// Probe raw config data for key presence to detect which preallocated
+			// struct pointers were mentioned in config files. This detects writes
+			// even when the value equals Go's zero value or the field's default.
+			for _, cr := range configResults {
+				markConfigKeysPresent(ctx, cr.target, cr.rawData)
+			}
+
+			// Clean up preallocated struct pointers that had no fields set.
+			// This must happen after all value sources (CLI, env, config) and before
+			// validation, so that required-field checks don't fire for unused struct groups.
+			if len(ctx.PreallocatedPtrs) > 0 {
+				cleanupPreallocatedPtrs(ctx)
 			}
 
 			// if b.params or any inner struct implements CfgStructPreValidate, call it

--- a/pkg/boa/param_meta.go
+++ b/pkg/boa/param_meta.go
@@ -42,6 +42,7 @@ type paramMeta struct {
 
 	// State
 	setByEnv        bool
+	setByConfig     bool
 	setPositionally bool
 	injected        bool
 	valuePtr        any            // cobra flag pointer (e.g., *string from StringP)

--- a/pkg/boa/struct_ptr_test.go
+++ b/pkg/boa/struct_ptr_test.go
@@ -1315,6 +1315,181 @@ func TestStructPtr_PreInitialized_KeptEvenIfNoFlagsSet(t *testing.T) {
 	}
 }
 
+// --- HasValue works correctly for fields inside struct pointers ---
+
+func TestStructPtr_HasValue_SetField(t *testing.T) {
+	// HasValue should return true for a field that was explicitly set via CLI
+	type Params struct {
+		DB *spDBConfig
+	}
+
+	hostHasValue := false
+	portHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+				portHasValue = ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--db-host", "myhost"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue(&p.DB.Host) to be true when --db-host was set")
+	}
+	// Port was not explicitly set, but has a default — HasValue should still be true
+	// (consistent with non-pointer struct behavior)
+	if !portHasValue {
+		t.Error("expected HasValue(&p.DB.Port) to be true (has default value)")
+	}
+}
+
+func TestStructPtr_HasValue_NoFieldsSet(t *testing.T) {
+	// When struct pointer is nil (nothing set), user should nil-check before HasValue.
+	// This test verifies the nil-check pattern works and mirrors are cleaned up properly.
+	type Params struct {
+		Name string     `descr:"name"`
+		DB   *spDBConfig
+	}
+
+	dbWasNil := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			dbWasNil = (p.DB == nil)
+		},
+	}).RunArgsE([]string{"--name", "test"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !dbWasNil {
+		t.Error("expected p.DB to be nil when no --db-* flags were set")
+	}
+}
+
+func TestStructPtr_HasValue_SetViaEnv(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" env:"SP_HV_HOST" optional:"true"`
+		Port int    `descr:"port" default:"5432" optional:"true"`
+	}
+	type Params struct {
+		DB *Inner
+	}
+
+	t.Setenv("DB_SP_HV_HOST", "env-host")
+
+	hostHasValue := false
+	portHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+				portHasValue = ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue(&p.DB.Host) to be true when set via env")
+	}
+	if !portHasValue {
+		t.Error("expected HasValue(&p.DB.Port) to be true (has default)")
+	}
+}
+
+func TestStructPtr_HasValue_SetViaConfigFile(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" optional:"true"`
+		Port int    `descr:"port" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Host": "cfg-host"},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	hostHasValue := false
+	portHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+				portHasValue = ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue(&p.DB.Host) to be true when set via config")
+	}
+	// Port was not in config and has no default — HasValue should be false
+	if portHasValue {
+		t.Error("expected HasValue(&p.DB.Port) to be false (not set, no default)")
+	}
+}
+
+func TestStructPtr_HasValue_NestedPtr(t *testing.T) {
+	// HasValue should work through nested pointer structs
+	type Inner struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Outer struct {
+		Name  string `descr:"name" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		Wrapper *Outer
+	}
+
+	valueHasValue := false
+	nameHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if p.Wrapper != nil && p.Wrapper.Inner != nil {
+				valueHasValue = ctx.HasValue(&p.Wrapper.Inner.Value)
+			}
+			if p.Wrapper != nil {
+				nameHasValue = ctx.HasValue(&p.Wrapper.Name)
+			}
+		},
+	}).RunArgsE([]string{"--wrapper-inner-value", "hello"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !valueHasValue {
+		t.Error("expected HasValue for nested value to be true")
+	}
+	if nameHasValue {
+		t.Error("expected HasValue for wrapper name to be false (not set, no default)")
+	}
+}
+
 // --- Flags from struct pointers show up in help ---
 
 func TestStructPtr_FlagsVisibleInHelp(t *testing.T) {

--- a/pkg/boa/struct_ptr_test.go
+++ b/pkg/boa/struct_ptr_test.go
@@ -1726,6 +1726,232 @@ func TestStructPtr_ConfigFile_EmptyObject_KeepsStructAlive(t *testing.T) {
 	}
 }
 
+// --- Cleanup verification: struct pointers nil'd when they should be ---
+
+func TestStructPtr_Cleanup_NoArgsAtAll_NestedPtrsAllNil(t *testing.T) {
+	type Inner struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Outer struct {
+		Label string `descr:"label" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		Other string `descr:"other" optional:"true"`
+		Outer *Outer
+	}
+
+	var gotOuter *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotOuter = p.Outer
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOuter != nil {
+		t.Errorf("expected Outer to be nil when no args/env/config, got %+v", gotOuter)
+	}
+}
+
+func TestStructPtr_Cleanup_CLISetsOuterNotInner(t *testing.T) {
+	// Setting a field on the outer struct but not the inner →
+	// outer non-nil, inner nil.
+	type Inner struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Outer struct {
+		Label string `descr:"label" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		Wrapper *Outer
+	}
+
+	var gotWrapper *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotWrapper = p.Wrapper
+		},
+	}).RunArgsE([]string{"--wrapper-label", "hello"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWrapper == nil {
+		t.Fatal("expected Wrapper to be non-nil (--wrapper-label was set)")
+	}
+	if gotWrapper.Label != "hello" {
+		t.Errorf("expected label='hello', got %q", gotWrapper.Label)
+	}
+	if gotWrapper.Inner != nil {
+		t.Errorf("expected Wrapper.Inner to be nil (nothing set it), got %+v", gotWrapper.Inner)
+	}
+}
+
+func TestStructPtr_Cleanup_ConfigMentionsOuterNotInner(t *testing.T) {
+	// Config sets a field on Outer but doesn't mention Inner.
+	type Inner struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Outer struct {
+		Label string `descr:"label" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Section    *Outer
+	}
+
+	cfgData := []byte(`{"Section": {"Label": "from-config"}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotSection *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotSection = p.Section
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotSection == nil {
+		t.Fatal("expected Section to be non-nil (config mentioned it)")
+	}
+	if gotSection.Label != "from-config" {
+		t.Errorf("expected label='from-config', got %q", gotSection.Label)
+	}
+	if gotSection.Inner != nil {
+		t.Errorf("expected Section.Inner to be nil (config didn't mention it), got %+v", gotSection.Inner)
+	}
+}
+
+func TestStructPtr_Cleanup_ConfigDoesNotMentionStruct(t *testing.T) {
+	// Config file exists but doesn't mention the struct pointer at all.
+	type Inner struct {
+		Host string `descr:"host" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Name       string `descr:"name" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData := []byte(`{"Name": "from-config"}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB != nil {
+		t.Errorf("expected DB to be nil (config didn't mention it), got %+v", gotDB)
+	}
+}
+
+func TestStructPtr_Cleanup_MultiplePtrs_ConfigMentionsOnlyOne(t *testing.T) {
+	type Params struct {
+		ConfigFile string         `configfile:"true" optional:"true"`
+		DB         *spDBConfig
+		Cache      *spCacheConfig
+	}
+
+	cfgData := []byte(`{"DB": {"Host": "config-db"}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *spDBConfig
+	var gotCache *spCacheConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			gotCache = p.Cache
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil (config mentioned it)")
+	}
+	if gotDB.Host != "config-db" {
+		t.Errorf("expected host='config-db', got %q", gotDB.Host)
+	}
+	if gotCache != nil {
+		t.Errorf("expected Cache to be nil (config didn't mention it), got %+v", gotCache)
+	}
+}
+
+func TestStructPtr_Cleanup_ThreeLevelNesting_OnlyMiddleSet(t *testing.T) {
+	// Three levels: *A -> *B -> *C. Only B's field is set via CLI.
+	// A should be non-nil (B is inside it), B should be non-nil (field set),
+	// C should be nil (nothing set it).
+	type C struct {
+		Deep string `descr:"deep" optional:"true"`
+	}
+	type B struct {
+		Mid string `descr:"mid" optional:"true"`
+		C   *C
+	}
+	type A struct {
+		Top string `descr:"top" optional:"true"`
+		B   *B
+	}
+	type Params struct {
+		Root *A
+	}
+
+	var gotRoot *A
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotRoot = p.Root
+		},
+	}).RunArgsE([]string{"--root-b-mid", "hello"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRoot == nil {
+		t.Fatal("expected Root to be non-nil")
+	}
+	if gotRoot.B == nil {
+		t.Fatal("expected Root.B to be non-nil (--root-b-mid was set)")
+	}
+	if gotRoot.B.Mid != "hello" {
+		t.Errorf("expected mid='hello', got %q", gotRoot.B.Mid)
+	}
+	if gotRoot.B.C != nil {
+		t.Errorf("expected Root.B.C to be nil (nothing set it), got %+v", gotRoot.B.C)
+	}
+}
+
 // --- Flags from struct pointers show up in help ---
 
 func TestStructPtr_FlagsVisibleInHelp(t *testing.T) {

--- a/pkg/boa/struct_ptr_test.go
+++ b/pkg/boa/struct_ptr_test.go
@@ -1490,6 +1490,242 @@ func TestStructPtr_HasValue_NestedPtr(t *testing.T) {
 	}
 }
 
+// --- JSON key matching: case-insensitive, json tags, boa name divergence ---
+
+func TestStructPtr_ConfigFile_CaseInsensitive_NoJsonTag(t *testing.T) {
+	// Without json tags, encoding/json matches field names case-insensitively.
+	// Config uses lowercase keys, struct has PascalCase fields.
+	type Inner struct {
+		Host string `descr:"host" optional:"true"`
+		Port int    `descr:"port" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// All lowercase JSON keys — should match PascalCase Go fields
+	cfgData := []byte(`{"db": {"host": "lower-host", "port": 9999}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	hostHasValue := false
+	portHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+				portHasValue = ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil (case-insensitive key match)")
+	}
+	if gotDB.Host != "lower-host" {
+		t.Errorf("expected host='lower-host', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 9999 {
+		t.Errorf("expected port=9999, got %d", gotDB.Port)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue for host to be true")
+	}
+	if !portHasValue {
+		t.Error("expected HasValue for port to be true")
+	}
+}
+
+func TestStructPtr_ConfigFile_WithJsonTag(t *testing.T) {
+	// json tags should be used for config file matching, not boa's name tag.
+	type Inner struct {
+		Host string `descr:"host" json:"hostname" optional:"true"`
+		Port int    `descr:"port" json:"listen_port" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// JSON uses the json tag names
+	cfgData := []byte(`{"DB": {"hostname": "tagged-host", "listen_port": 8080}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	hostHasValue := false
+	portHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+				portHasValue = ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when config uses json tag names")
+	}
+	if gotDB.Host != "tagged-host" {
+		t.Errorf("expected host='tagged-host', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 8080 {
+		t.Errorf("expected port=8080, got %d", gotDB.Port)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue for host to be true")
+	}
+	if !portHasValue {
+		t.Error("expected HasValue for port to be true")
+	}
+}
+
+func TestStructPtr_ConfigFile_JsonTagCaseInsensitive(t *testing.T) {
+	// Case-insensitive matching should also work with json tags.
+	type Inner struct {
+		Host string `descr:"host" json:"hostname" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// JSON uses uppercase of the json tag name
+	cfgData := []byte(`{"DB": {"HOSTNAME": "upper-host"}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	hostHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil (case-insensitive json tag match)")
+	}
+	if gotDB.Host != "upper-host" {
+		t.Errorf("expected host='upper-host', got %q", gotDB.Host)
+	}
+	if !hostHasValue {
+		t.Error("expected HasValue for host to be true")
+	}
+}
+
+func TestStructPtr_ConfigFile_BoaNameDiffersFromJsonName(t *testing.T) {
+	// The boa flag name (from name tag or auto-generated) can be completely
+	// different from the json key. Config files use json names, not boa names.
+	// Here: boa name is "apple" but json key is "banana".
+	type Inner struct {
+		Fruit string `name:"apple" json:"banana" descr:"a fruit" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Box        *Inner
+	}
+
+	// JSON uses "banana" (the json tag), not "apple" (the boa name)
+	cfgData := []byte(`{"Box": {"banana": "yellow"}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotBox *Inner
+	fruitHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotBox = p.Box
+			if p.Box != nil {
+				fruitHasValue = ctx.HasValue(&p.Box.Fruit)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBox == nil {
+		t.Fatal("expected Box to be non-nil when config uses json tag name")
+	}
+	if gotBox.Fruit != "yellow" {
+		t.Errorf("expected fruit='yellow', got %q", gotBox.Fruit)
+	}
+	if !fruitHasValue {
+		t.Error("expected HasValue for fruit to be true")
+	}
+}
+
+func TestStructPtr_ConfigFile_EmptyObject_KeepsStructAlive(t *testing.T) {
+	// An empty object {"DB": {}} should keep the struct pointer alive because
+	// the config explicitly mentioned the section. Individual fields won't
+	// have HasValue=true, but the struct pointer is non-nil.
+	type Inner struct {
+		Host string `descr:"host" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData := []byte(`{"DB": {}}`)
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	hostHasValue := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				hostHasValue = ctx.HasValue(&p.DB.Host)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when config mentions DB section (even empty)")
+	}
+	if hostHasValue {
+		t.Error("expected HasValue for host to be false (not in config, no default)")
+	}
+}
+
 // --- Flags from struct pointers show up in help ---
 
 func TestStructPtr_FlagsVisibleInHelp(t *testing.T) {

--- a/pkg/boa/struct_ptr_test.go
+++ b/pkg/boa/struct_ptr_test.go
@@ -1,0 +1,1342 @@
+package boa
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Shared struct types for struct pointer tests
+
+type spDBConfig struct {
+	Host string `descr:"database host" default:"localhost"`
+	Port int    `descr:"database port" default:"5432"`
+}
+
+type spCacheConfig struct {
+	TTL     int    `descr:"cache ttl seconds" default:"300"`
+	Backend string `descr:"cache backend" default:"memory"`
+}
+
+// --- Basic: struct pointer nil when no flags set ---
+
+func TestStructPtr_NilWhenNoFlagsSet(t *testing.T) {
+	type Params struct {
+		Name string     `descr:"app name"`
+		DB   *spDBConfig // pointer — should be nil if no --db-* flags given
+	}
+
+	var gotDB *spDBConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--name", "myapp"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB != nil {
+		t.Errorf("expected DB to be nil when no --db-* flags set, got %+v", gotDB)
+	}
+}
+
+// --- CLI arg triggers instantiation ---
+
+func TestStructPtr_SetViaCLI_Host(t *testing.T) {
+	type Params struct {
+		Name string      `descr:"app name"`
+		DB   *spDBConfig
+	}
+
+	var gotDB *spDBConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--name", "myapp", "--db-host", "db.example.com"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when --db-host was set")
+	}
+	if gotDB.Host != "db.example.com" {
+		t.Errorf("expected host='db.example.com', got %q", gotDB.Host)
+	}
+	// Port should get its default
+	if gotDB.Port != 5432 {
+		t.Errorf("expected port=5432 (default), got %d", gotDB.Port)
+	}
+}
+
+func TestStructPtr_SetViaCLI_Port(t *testing.T) {
+	type Params struct {
+		DB *spDBConfig
+	}
+
+	var gotDB *spDBConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--db-port", "3306"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when --db-port was set")
+	}
+	if gotDB.Port != 3306 {
+		t.Errorf("expected port=3306, got %d", gotDB.Port)
+	}
+	if gotDB.Host != "localhost" {
+		t.Errorf("expected host='localhost' (default), got %q", gotDB.Host)
+	}
+}
+
+// --- Env var triggers instantiation ---
+
+func TestStructPtr_SetViaEnv(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" env:"SP_DB_HOST"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		DB *Inner
+	}
+
+	t.Setenv("DB_SP_DB_HOST", "env-host.example.com")
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when env was set")
+	}
+	if gotDB.Host != "env-host.example.com" {
+		t.Errorf("expected host='env-host.example.com', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 5432 {
+		t.Errorf("expected port=5432 (default), got %d", gotDB.Port)
+	}
+}
+
+func TestStructPtr_SetViaEnv_ExplicitEnvTag(t *testing.T) {
+	type Inner struct {
+		Value string `descr:"a value" env:"MY_CUSTOM_VAR"`
+	}
+	type Params struct {
+		Thing *Inner
+	}
+
+	t.Setenv("THING_MY_CUSTOM_VAR", "from-env")
+
+	var gotThing *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherDefault,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotThing = p.Thing
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotThing == nil {
+		t.Fatal("expected Thing to be non-nil when env was set")
+	}
+	if gotThing.Value != "from-env" {
+		t.Errorf("expected value='from-env', got %q", gotThing.Value)
+	}
+}
+
+// --- Config file triggers instantiation ---
+
+func TestStructPtr_SetViaConfigFile(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Host": "config-host", "Port": 9999},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when set via config file")
+	}
+	if gotDB.Host != "config-host" {
+		t.Errorf("expected host='config-host', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 9999 {
+		t.Errorf("expected port=9999, got %d", gotDB.Port)
+	}
+}
+
+// --- CLI + Env combination ---
+
+func TestStructPtr_CLIOverridesEnv(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" env:"SP_CLI_DB_HOST"`
+	}
+	type Params struct {
+		DB *Inner
+	}
+
+	t.Setenv("DB_SP_CLI_DB_HOST", "env-host")
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--db-host", "cli-host"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil")
+	}
+	if gotDB.Host != "cli-host" {
+		t.Errorf("expected host='cli-host' (CLI overrides env), got %q", gotDB.Host)
+	}
+}
+
+// --- CLI + Config file combination ---
+
+func TestStructPtr_CLIOverridesConfigFile(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Host": "config-host", "Port": 3306},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath, "--db-host", "cli-host"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil")
+	}
+	if gotDB.Host != "cli-host" {
+		t.Errorf("expected host='cli-host' (CLI overrides config), got %q", gotDB.Host)
+	}
+	if gotDB.Port != 3306 {
+		t.Errorf("expected port=3306 (from config), got %d", gotDB.Port)
+	}
+}
+
+// --- Two struct pointers, only one set ---
+
+func TestStructPtr_TwoPointers_OnlyOneSet(t *testing.T) {
+	type Params struct {
+		DB    *spDBConfig
+		Cache *spCacheConfig
+	}
+
+	var gotDB *spDBConfig
+	var gotCache *spCacheConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			gotCache = p.Cache
+		},
+	}).RunArgsE([]string{"--db-host", "mydb"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil")
+	}
+	if gotDB.Host != "mydb" {
+		t.Errorf("expected host='mydb', got %q", gotDB.Host)
+	}
+	if gotCache != nil {
+		t.Errorf("expected Cache to be nil, got %+v", gotCache)
+	}
+}
+
+// --- Both struct pointers set ---
+
+func TestStructPtr_TwoPointers_BothSet(t *testing.T) {
+	type Params struct {
+		DB    *spDBConfig
+		Cache *spCacheConfig
+	}
+
+	var gotDB *spDBConfig
+	var gotCache *spCacheConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			gotCache = p.Cache
+		},
+	}).RunArgsE([]string{"--db-host", "mydb", "--cache-ttl", "60"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil")
+	}
+	if gotCache == nil {
+		t.Fatal("expected Cache to be non-nil")
+	}
+	if gotDB.Host != "mydb" {
+		t.Errorf("expected db host='mydb', got %q", gotDB.Host)
+	}
+	if gotCache.TTL != 60 {
+		t.Errorf("expected cache ttl=60, got %d", gotCache.TTL)
+	}
+	if gotCache.Backend != "memory" {
+		t.Errorf("expected cache backend='memory' (default), got %q", gotCache.Backend)
+	}
+}
+
+// --- Nested struct pointer inside struct pointer ---
+
+func TestStructPtr_NestedPtrInPtr(t *testing.T) {
+	type Inner struct {
+		Value string `descr:"inner value"`
+	}
+	type Outer struct {
+		Name  string `descr:"outer name" default:"outer-default"`
+		Inner *Inner
+	}
+	type Params struct {
+		Wrapper *Outer
+	}
+
+	var gotWrapper *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotWrapper = p.Wrapper
+		},
+	}).RunArgsE([]string{"--wrapper-inner-value", "deep"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWrapper == nil {
+		t.Fatal("expected Wrapper to be non-nil")
+	}
+	if gotWrapper.Inner == nil {
+		t.Fatal("expected Wrapper.Inner to be non-nil")
+	}
+	if gotWrapper.Inner.Value != "deep" {
+		t.Errorf("expected inner value='deep', got %q", gotWrapper.Inner.Value)
+	}
+	if gotWrapper.Name != "outer-default" {
+		t.Errorf("expected outer name='outer-default', got %q", gotWrapper.Name)
+	}
+}
+
+func TestStructPtr_NestedPtrInPtr_NoneSet(t *testing.T) {
+	type Inner struct {
+		Value string `descr:"inner value" optional:"true"`
+	}
+	type Outer struct {
+		Name  string `descr:"outer name" default:"x" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		Other   string `descr:"other" optional:"true"`
+		Wrapper *Outer
+	}
+
+	var gotWrapper *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotWrapper = p.Wrapper
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWrapper != nil {
+		t.Errorf("expected Wrapper to be nil, got %+v", gotWrapper)
+	}
+}
+
+func TestStructPtr_NestedPtrInPtr_OnlyInnerSet(t *testing.T) {
+	// Setting only the deeply nested field should instantiate the full chain
+	type Inner struct {
+		Value string `descr:"inner value"`
+	}
+	type Outer struct {
+		Name  string `descr:"outer name" optional:"true"`
+		Inner *Inner
+	}
+	type Params struct {
+		Wrapper *Outer
+	}
+
+	var gotWrapper *Outer
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotWrapper = p.Wrapper
+		},
+	}).RunArgsE([]string{"--wrapper-inner-value", "deep"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotWrapper == nil {
+		t.Fatal("expected Wrapper to be non-nil (inner field was set)")
+	}
+	if gotWrapper.Inner == nil {
+		t.Fatal("expected Wrapper.Inner to be non-nil")
+	}
+	if gotWrapper.Inner.Value != "deep" {
+		t.Errorf("expected inner value='deep', got %q", gotWrapper.Inner.Value)
+	}
+}
+
+// --- Embedded (anonymous) struct pointer ---
+
+func TestStructPtr_Embedded_Anonymous(t *testing.T) {
+	type CommonOpts struct {
+		Verbose bool `descr:"verbose" optional:"true"`
+	}
+	type Params struct {
+		*CommonOpts
+		Name string `descr:"name"`
+	}
+
+	var gotParams *Params
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotParams = p
+		},
+	}).RunArgsE([]string{"--name", "test", "--verbose"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotParams.CommonOpts == nil {
+		t.Fatal("expected embedded CommonOpts to be non-nil when --verbose was set")
+	}
+	if !gotParams.Verbose {
+		t.Error("expected verbose=true")
+	}
+}
+
+func TestStructPtr_Embedded_Anonymous_NilWhenNotSet(t *testing.T) {
+	type CommonOpts struct {
+		Verbose bool `descr:"verbose" optional:"true"`
+	}
+	type Params struct {
+		*CommonOpts
+		Name string `descr:"name"`
+	}
+
+	var gotParams *Params
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotParams = p
+		},
+	}).RunArgsE([]string{"--name", "test"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotParams.CommonOpts != nil {
+		t.Errorf("expected embedded CommonOpts to be nil when --verbose was not set, got %+v", gotParams.CommonOpts)
+	}
+}
+
+// --- Custom validator on struct pointer fields ---
+
+func TestStructPtr_CustomValidator(t *testing.T) {
+	type Params struct {
+		DB *spDBConfig
+	}
+
+	validatorCalled := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFunc: func(p *Params, cmd *cobra.Command) error {
+			// We'd need HookContext to set a validator on db-port...
+			// but this tests that the struct pointer fields are accessible for validation
+			return nil
+		},
+		PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+			if p.DB != nil {
+				validatorCalled = true
+				if p.DB.Port < 1 || p.DB.Port > 65535 {
+					return NewUserInputErrorf("port must be between 1 and 65535")
+				}
+			}
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--db-port", "3306"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !validatorCalled {
+		t.Error("expected custom validator to be called when DB was set")
+	}
+}
+
+func TestStructPtr_CustomValidator_NotCalledWhenNil(t *testing.T) {
+	type Params struct {
+		Name string     `descr:"name"`
+		DB   *spDBConfig
+	}
+
+	validatorCalled := false
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+			if p.DB != nil {
+				validatorCalled = true
+			}
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--name", "test"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if validatorCalled {
+		t.Error("expected validator NOT to be called when DB is nil")
+	}
+}
+
+func TestStructPtr_CustomValidatorViaHookCtx(t *testing.T) {
+	type Params struct {
+		DB *spDBConfig
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		PostCreateFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			// p.DB should be non-nil here (preallocated) so we can get the param
+			if p.DB == nil {
+				t.Error("expected DB to be preallocated in PostCreateFuncCtx")
+				return nil
+			}
+			portParam := ctx.GetParam(&p.DB.Port)
+			if portParam == nil {
+				t.Error("expected to find port param via HookContext")
+				return nil
+			}
+			portParam.SetCustomValidator(func(val any) error {
+				v := val.(int)
+				if v < 1024 {
+					return NewUserInputErrorf("port must be >= 1024, got %d", v)
+				}
+				return nil
+			})
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--db-port", "80"})
+
+	if err == nil {
+		t.Error("expected validation error for port < 1024")
+	}
+}
+
+// --- AlternativesFunc on struct pointer fields ---
+
+func TestStructPtr_AlternativesFunc(t *testing.T) {
+	type Params struct {
+		DB *spDBConfig
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		PostCreateFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			if p.DB == nil {
+				t.Error("expected DB to be preallocated in PostCreateFuncCtx")
+				return nil
+			}
+			hostParam := ctx.GetParam(&p.DB.Host)
+			if hostParam == nil {
+				t.Error("expected to find host param via HookContext")
+				return nil
+			}
+			hostParam.SetAlternativesFunc(func(cmd *cobra.Command, args []string, toComplete string) []string {
+				return []string{"localhost", "db.prod", "db.staging"}
+			})
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--db-host", "localhost"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStructPtr_Alternatives_Strict(t *testing.T) {
+	type Inner struct {
+		Mode string `descr:"mode" alts:"fast,slow" strict:"true"`
+	}
+	type Params struct {
+		Config *Inner
+	}
+
+	// Valid value
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--config-mode", "fast"})
+
+	if err != nil {
+		t.Fatalf("unexpected error for valid alt: %v", err)
+	}
+
+	// Invalid value
+	err = (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--config-mode", "invalid"})
+
+	if err == nil {
+		t.Error("expected error for invalid alt value")
+	}
+}
+
+// --- Validation tags on struct pointer fields ---
+
+func TestStructPtr_ValidationTags_MinMax(t *testing.T) {
+	type Inner struct {
+		Port int `descr:"port" min:"1" max:"65535"`
+	}
+	type Params struct {
+		Server *Inner
+	}
+
+	// Valid
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--server-port", "8080"})
+
+	if err != nil {
+		t.Fatalf("unexpected error for valid port: %v", err)
+	}
+
+	// Invalid (too high)
+	err = (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--server-port", "99999"})
+
+	if err == nil {
+		t.Error("expected validation error for port > 65535")
+	}
+}
+
+func TestStructPtr_ValidationTags_Pattern(t *testing.T) {
+	type Inner struct {
+		Tag string `descr:"tag" pattern:"^v[0-9]+\\.[0-9]+$"`
+	}
+	type Params struct {
+		Release *Inner
+	}
+
+	// Valid
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--release-tag", "v1.0"})
+
+	if err != nil {
+		t.Fatalf("unexpected error for valid tag: %v", err)
+	}
+
+	// Invalid
+	err = (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--release-tag", "bad"})
+
+	if err == nil {
+		t.Error("expected validation error for tag not matching pattern")
+	}
+}
+
+// --- Required fields inside struct pointer ---
+
+func TestStructPtr_RequiredFieldInsidePtr_NoErrorWhenStructNil(t *testing.T) {
+	// If the struct pointer is nil (nothing set), required fields inside
+	// should NOT trigger validation errors.
+	type Inner struct {
+		Host string `descr:"host"` // required by default
+	}
+	type Params struct {
+		Other  string `descr:"other" optional:"true"`
+		Server *Inner
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("expected no error when struct ptr is nil, but got: %v", err)
+	}
+}
+
+func TestStructPtr_RequiredFieldInsidePtr_ErrorWhenPartiallySet(t *testing.T) {
+	// If one field is set but another required field in the same struct isn't,
+	// that should be a validation error.
+	type Inner struct {
+		Host string `descr:"host"`              // required
+		Port int    `descr:"port" optional:"true"` // optional
+		Name string `descr:"name"`              // required
+	}
+	type Params struct {
+		Server *Inner
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--server-host", "example.com"})
+	// Host is set but Name is required and not set — should error
+
+	if err == nil {
+		t.Error("expected validation error for missing required --server-name when --server-host was set")
+	}
+}
+
+// --- Mixed pointer and non-pointer structs ---
+
+func TestStructPtr_MixedPointerAndValue(t *testing.T) {
+	type Params struct {
+		DB    spDBConfig    // value struct — always present
+		Cache *spCacheConfig // pointer struct — nil if not set
+	}
+
+	var gotDB spDBConfig
+	var gotCache *spCacheConfig
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			gotCache = p.Cache
+		},
+	}).RunArgsE([]string{"--db-host", "mydb"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB.Host != "mydb" {
+		t.Errorf("expected db host='mydb', got %q", gotDB.Host)
+	}
+	if gotCache != nil {
+		t.Errorf("expected Cache to be nil, got %+v", gotCache)
+	}
+}
+
+// --- Struct pointer with all-optional fields ---
+
+func TestStructPtr_AllOptionalFields_NilWhenNotSet(t *testing.T) {
+	type Inner struct {
+		Debug   bool   `descr:"debug" optional:"true"`
+		LogFile string `descr:"log file" optional:"true"`
+	}
+	type Params struct {
+		Logging *Inner
+	}
+
+	var gotLogging *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotLogging = p.Logging
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLogging != nil {
+		t.Errorf("expected Logging to be nil, got %+v", gotLogging)
+	}
+}
+
+func TestStructPtr_AllOptionalFields_SetWhenOneProvided(t *testing.T) {
+	type Inner struct {
+		Debug   bool   `descr:"debug" optional:"true"`
+		LogFile string `descr:"log file" optional:"true"`
+	}
+	type Params struct {
+		Logging *Inner
+	}
+
+	var gotLogging *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotLogging = p.Logging
+		},
+	}).RunArgsE([]string{"--logging-debug"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotLogging == nil {
+		t.Fatal("expected Logging to be non-nil when --logging-debug was set")
+	}
+	if !gotLogging.Debug {
+		t.Error("expected debug=true")
+	}
+}
+
+// --- Defaults inside struct pointer should not trigger instantiation ---
+
+func TestStructPtr_DefaultsAloneDontInstantiate(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" optional:"true"`
+		Port int    `descr:"port" default:"5432" optional:"true"`
+	}
+	type Params struct {
+		Other string `descr:"other" optional:"true"`
+		DB    *Inner
+	}
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB != nil {
+		t.Errorf("expected DB to be nil (defaults alone shouldn't instantiate), got %+v", gotDB)
+	}
+}
+
+// --- Env + Config file combination with struct pointer ---
+
+func TestStructPtr_EnvAndConfigFile(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" env:"SP_ENV_CFG_HOST"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// Config sets port
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Port": 3306},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	// Env sets host (prefixed by named struct "DB")
+	t.Setenv("DB_SP_ENV_CFG_HOST", "env-host")
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil")
+	}
+	if gotDB.Host != "env-host" {
+		t.Errorf("expected host='env-host', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 3306 {
+		t.Errorf("expected port=3306 (from config), got %d", gotDB.Port)
+	}
+}
+
+// --- Config file should not erase struct pointer ---
+
+func TestStructPtr_ConfigFileKeepsStructAlive(t *testing.T) {
+	// Values from config file should keep the struct pointer non-nil
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" optional:"true"`
+		Port int    `descr:"port" default:"5432" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Host": "config-host"},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when set via config file")
+	}
+	if gotDB.Host != "config-host" {
+		t.Errorf("expected host='config-host', got %q", gotDB.Host)
+	}
+}
+
+func TestStructPtr_ConfigFileSetsZeroValue_StillKeepsStruct(t *testing.T) {
+	// Config file explicitly sets a field to the Go zero value (0 for int).
+	// The struct pointer should remain non-nil because the user explicitly
+	// provided the value in the config file.
+	type Inner struct {
+		Count int `descr:"count" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Stats      *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Stats": map[string]any{"Count": 0},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "cfg.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotStats *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotStats = p.Stats
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStats == nil {
+		t.Fatal("expected Stats to be non-nil when config file explicitly set Count=0")
+	}
+}
+
+func TestStructPtr_ConfigFileSetsDefaultValue_StillKeepsStruct(t *testing.T) {
+	// Even if config sets same value as default, the struct should stay alive
+	// because the user explicitly provided it in a config file.
+	// Key-presence detection handles this — we detect the key in JSON, not
+	// the value.
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"DB": map[string]any{"Host": "localhost"}, // same as default!
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "cfg.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when config file explicitly set the field (even to default value)")
+	}
+}
+
+func TestStructPtr_SubstructOwnConfigFile(t *testing.T) {
+	// The inner struct has its OWN configfile:"true" field, not the root.
+	// This tests that substruct config file loading preserves the struct pointer.
+	type Inner struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Host       string `descr:"host" default:"localhost" optional:"true"`
+		Port       int    `descr:"port" default:"5432" optional:"true"`
+	}
+	type Params struct {
+		Name string `descr:"name" optional:"true"`
+		DB   *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Host": "substruct-host",
+		"Port": 9999,
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "db.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--db-config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB to be non-nil when loaded via its own config file")
+	}
+	if gotDB.Host != "substruct-host" {
+		t.Errorf("expected host='substruct-host', got %q", gotDB.Host)
+	}
+	if gotDB.Port != 9999 {
+		t.Errorf("expected port=9999, got %d", gotDB.Port)
+	}
+}
+
+func TestStructPtr_SubstructOwnConfigFile_ZeroValue(t *testing.T) {
+	// Substruct config file sets a field to the Go zero value.
+	type Inner struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Count      int    `descr:"count" optional:"true"`
+	}
+	type Params struct {
+		Stats *Inner
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Count": 0,
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "stats.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotStats *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotStats = p.Stats
+		},
+	}).RunArgsE([]string{"--stats-config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStats == nil {
+		t.Fatal("expected Stats to be non-nil when loaded via its own config file")
+	}
+}
+
+func TestStructPtr_TwoLevelNestedPtrs_ConfigFile(t *testing.T) {
+	// X -> *Y -> *Z, config file sets a field in Z.
+	type Z struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Y struct {
+		Label string `descr:"label" optional:"true"`
+		Inner *Z
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Outer      *Y
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Outer": map[string]any{
+			"Inner": map[string]any{"Value": "deep-config"},
+		},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotOuter *Y
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotOuter = p.Outer
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOuter == nil {
+		t.Fatal("expected Outer to be non-nil")
+	}
+	if gotOuter.Inner == nil {
+		t.Fatal("expected Outer.Inner to be non-nil")
+	}
+	if gotOuter.Inner.Value != "deep-config" {
+		t.Errorf("expected value='deep-config', got %q", gotOuter.Inner.Value)
+	}
+}
+
+func TestStructPtr_TwoLevelNestedPtrs_ConfigFile_ZeroValue(t *testing.T) {
+	// X -> *Y -> *Z, config file sets a field in Z to zero value.
+	type Z struct {
+		Count int `descr:"count" optional:"true"`
+	}
+	type Y struct {
+		Inner *Z
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Outer      *Y
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Outer": map[string]any{
+			"Inner": map[string]any{"Count": 0},
+		},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotOuter *Y
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotOuter = p.Outer
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOuter == nil {
+		t.Fatal("expected Outer to be non-nil")
+	}
+	if gotOuter.Inner == nil {
+		t.Fatal("expected Outer.Inner to be non-nil (config set Count=0)")
+	}
+}
+
+func TestStructPtr_TwoLevelNestedPtrs_OnlyMiddleSetViaConfig(t *testing.T) {
+	// Config sets a field on Y but not Z — Y should be non-nil, Z should be nil.
+	type Z struct {
+		Value string `descr:"value" optional:"true"`
+	}
+	type Y struct {
+		Label string `descr:"label" optional:"true"`
+		Inner *Z
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Outer      *Y
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Outer": map[string]any{
+			"Label": "from-config",
+		},
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotOuter *Y
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotOuter = p.Outer
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOuter == nil {
+		t.Fatal("expected Outer to be non-nil")
+	}
+	if gotOuter.Label != "from-config" {
+		t.Errorf("expected label='from-config', got %q", gotOuter.Label)
+	}
+	if gotOuter.Inner != nil {
+		t.Errorf("expected Outer.Inner to be nil (not mentioned in config), got %+v", gotOuter.Inner)
+	}
+}
+
+// --- Pre-initialized struct pointer should be kept ---
+
+func TestStructPtr_PreInitialized_KeptEvenIfNoFlagsSet(t *testing.T) {
+	type Inner struct {
+		Host string `descr:"host" default:"localhost" optional:"true"`
+	}
+	type Params struct {
+		DB *Inner
+	}
+
+	params := &Params{DB: &Inner{Host: "pre-init"}}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		Params:      params,
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if params.DB == nil {
+		t.Fatal("expected pre-initialized DB to remain non-nil")
+	}
+	if params.DB.Host != "pre-init" {
+		t.Errorf("expected host='pre-init', got %q", params.DB.Host)
+	}
+}
+
+// --- Flags from struct pointers show up in help ---
+
+func TestStructPtr_FlagsVisibleInHelp(t *testing.T) {
+	type Params struct {
+		Name string     `descr:"app name"`
+		DB   *spDBConfig
+	}
+
+	cmd := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).ToCobra()
+
+	// Check that db-host and db-port flags exist
+	hostFlag := cmd.Flags().Lookup("db-host")
+	if hostFlag == nil {
+		t.Error("expected --db-host flag to be registered")
+	}
+
+	portFlag := cmd.Flags().Lookup("db-port")
+	if portFlag == nil {
+		t.Error("expected --db-port flag to be registered")
+	}
+}


### PR DESCRIPTION
## Summary
- Nil struct pointer fields (`DB *DBConfig`) are now preallocated during init so their child fields get registered as CLI flags, env vars, and config file targets
- After all value sources are applied, unused struct pointers are nil'd back — `p.DB == nil` means nothing was configured, `p.DB != nil` means at least one field was set
- Config file key-presence detection probes raw JSON bytes to correctly preserve structs even when values equal Go's zero value or the field's default

## Details
- **Preallocate phase**: before first traverse and init hooks, so users can access `&params.DB.Port` in `InitFuncCtx`/`PostCreateFuncCtx`
- **Cleanup phase**: after CLI parsing, env reading, and config loading but before validation — required fields inside nil'd structs don't trigger errors
- **Config detection**: uses `map[string]json.RawMessage` key-presence probing (JSON-compatible formats); stops at pointer-to-struct boundaries for correct nested cleanup
- Nested pointer structs work: `*Outer` containing `*Inner` — each level independently nil'd if unused

## Test plan
- [x] 38 new tests in `struct_ptr_test.go` covering:
  - CLI, env var, config file triggers (including zero-value and same-as-default)
  - Substruct own config file loading
  - 2-level nested pointer structs (`*Y` → `*Z`) with selective config
  - Embedded anonymous pointer structs
  - Custom validators, alternatives, validation tags (min/max/pattern)
  - HookContext access to preallocated struct fields
  - Mixed pointer/value structs, pre-initialized structs, help output
- [x] Full existing test suite passes (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Struct pointer fields now act as optional parameter groups, instantiated only when CLI/env/config mention them; supports nested and embedded pointers and exposes their flags in help.
  * Config-file presence detection preserves pointer sections even when entries are empty or zero-valued.

* **Bug Fixes**
  * Parameters loaded from config files are correctly treated as "set" for presence and precedence.

* **Documentation**
  * Added guidance on pointer-to-struct behavior, validation, and hooks.

* **Tests**
  * Extensive tests covering pointer instantiation, precedence, validation, and help output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->