### PR TITLE
refactor: key parameter mirrors by field-index path

### DIFF
--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -366,14 +366,42 @@ func newHookContext(pctx *processingContext) *HookContext {
 //	        return nil
 //	    },
 //	}
+//
+// GetParam returns nil and logs a descriptive slog.Error if the field pointer
+// does not belong to the parameters struct associated with this HookContext —
+// for example, if the caller passes a pointer to a field in an unrelated
+// struct, in a different command's params, or in a substruct that was never
+// registered (e.g., tagged boa:"ignore"). Callers using the idiomatic
+// ctx.GetParam(&p.X).SetY(...) pattern will still see a nil-dereference crash
+// if they chain against a nil return, but the preceding slog.Error log line
+// will carry the descriptive cause so the real bug is visible in the output.
+// Callers that want "probe without crashing" semantics can explicitly check
+// for nil.
 func (c *HookContext) GetParam(fieldPtr any) Param {
 	if param, ok := fieldPtr.(Param); ok {
 		return param
 	}
 	if c == nil || c.ctx == nil || c.ctx.mirrorByPath == nil {
+		slog.Error("boa.HookContext.GetParam: called on a nil or uninitialized HookContext (no parameters are registered)")
 		return nil
 	}
-	addr := reflect.ValueOf(fieldPtr).UnsafePointer()
+	if fieldPtr == nil {
+		slog.Error("boa.HookContext.GetParam: fieldPtr is nil")
+		return nil
+	}
+	rv := reflect.ValueOf(fieldPtr)
+	if rv.Kind() != reflect.Ptr {
+		slog.Error("boa.HookContext.GetParam: fieldPtr must be a pointer to a struct field",
+			"got_type", fmt.Sprintf("%T", fieldPtr))
+		return nil
+	}
+	if rv.IsNil() {
+		slog.Error("boa.HookContext.GetParam: fieldPtr is a typed nil",
+			"got_type", fmt.Sprintf("%T", fieldPtr))
+		return nil
+	}
+
+	addr := rv.UnsafePointer()
 	// Rebuild the address cache if it was invalidated (e.g., after a subtree removal).
 	if c.ctx.addrToPath == nil {
 		c.ctx.rebuildAddrToPath()
@@ -388,6 +416,16 @@ func (c *HookContext) GetParam(fieldPtr any) Param {
 			return c.ctx.mirrorByPath[path]
 		}
 	}
+	slog.Error(
+		"boa.HookContext.GetParam: the field pointer does not belong to the parameters struct associated with this HookContext. "+
+			"Likely causes: "+
+			"(1) you passed a pointer to a field in an unrelated struct; "+
+			"(2) you passed a field from a different command's params in the same command tree (each command has its own mirror set); "+
+			"(3) you passed a field from a substruct that was not registered (e.g., one tagged boa:\"ignore\" or of an unsupported type); "+
+			"(4) you passed a field from a different instance of the same params type than the one registered with this command.",
+		"got_type", fmt.Sprintf("%T", fieldPtr),
+		"address", fmt.Sprintf("%p", addr),
+	)
 	return nil
 }
 

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -411,8 +411,13 @@ func (c *HookContext) GetParam(fieldPtr any) Param {
 	}
 	// Fallback: walk the root to discover a matching leaf address. This handles
 	// the case where the user reassigned a substruct after the cache was built.
+	// On a hit, repair the cache opportunistically so the next lookup for this
+	// address is O(1) again.
 	if c.ctx.rootStructPtr != nil {
 		if path, ok := c.ctx.findPathByAddr(addr); ok {
+			if c.ctx.addrToPath != nil {
+				c.ctx.addrToPath[addr] = path
+			}
 			return c.ctx.mirrorByPath[path]
 		}
 	}

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"unsafe"
 
 	"github.com/spf13/cobra"
 )
@@ -334,8 +333,20 @@ type CmdIfc interface {
 // HookContext provides access to parameter mirrors and advanced configuration APIs
 // within startup hooks. This allows hooks to access and modify parameters
 // programmatically (SetDefault, SetAlternatives, SetRequiredFn, etc.).
+//
+// Internally, mirrors are stored keyed by their declared-index path from the root
+// parameters struct. This keeps the identity of a mirror stable even when pointer
+// substructs are reassigned, and makes subtree operations efficient string-prefix
+// queries rather than address walks. The address → path cache exists solely to
+// support the ergonomic GetParam(&params.Field) API.
 type HookContext struct {
-	rawAddrToMirror map[unsafe.Pointer]Param
+	ctx *processingContext
+}
+
+// newHookContext wraps a processingContext for hook exposure.
+// Returns a usable (even if empty) HookContext — it never returns nil.
+func newHookContext(pctx *processingContext) *HookContext {
+	return &HookContext{ctx: pctx}
 }
 
 // GetParam returns the Param for any field pointer.
@@ -359,21 +370,37 @@ func (c *HookContext) GetParam(fieldPtr any) Param {
 	if param, ok := fieldPtr.(Param); ok {
 		return param
 	}
-	if c.rawAddrToMirror == nil {
+	if c == nil || c.ctx == nil || c.ctx.mirrorByPath == nil {
 		return nil
 	}
 	addr := reflect.ValueOf(fieldPtr).UnsafePointer()
-	return c.rawAddrToMirror[addr]
+	// Rebuild the address cache if it was invalidated (e.g., after a subtree removal).
+	if c.ctx.addrToPath == nil {
+		c.ctx.rebuildAddrToPath()
+	}
+	if path, ok := c.ctx.addrToPath[addr]; ok {
+		return c.ctx.mirrorByPath[path]
+	}
+	// Fallback: walk the root to discover a matching leaf address. This handles
+	// the case where the user reassigned a substruct after the cache was built.
+	if c.ctx.rootStructPtr != nil {
+		if path, ok := c.ctx.findPathByAddr(addr); ok {
+			return c.ctx.mirrorByPath[path]
+		}
+	}
+	return nil
 }
 
-// AllMirrors returns all parameter mirrors in the context.
+// AllMirrors returns all parameter mirrors in the context in declaration/insertion order.
 func (c *HookContext) AllMirrors() []Param {
-	if c.rawAddrToMirror == nil {
+	if c == nil || c.ctx == nil || c.ctx.mirrorByPath == nil {
 		return nil
 	}
-	result := make([]Param, 0, len(c.rawAddrToMirror))
-	for _, param := range c.rawAddrToMirror {
-		result = append(result, param)
+	result := make([]Param, 0, len(c.ctx.pathOrder))
+	for _, p := range c.ctx.pathOrder {
+		if m, ok := c.ctx.mirrorByPath[p]; ok {
+			result = append(result, m)
+		}
 	}
 	return result
 }

--- a/pkg/boa/foreign_field_lookup_test.go
+++ b/pkg/boa/foreign_field_lookup_test.go
@@ -1,0 +1,212 @@
+package boa
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// The tests in this file verify that HookContext.GetParam fails loudly *via
+// logging* (but still returns nil) when called with a field pointer that does
+// not belong to the parameters struct associated with the context.
+//
+// Silent nil was the prior behavior. That led to delayed "invalid memory
+// address or nil pointer dereference" crashes at the caller's chained method
+// call, with no indication that the root cause was an upstream mis-lookup.
+//
+// The current behavior is: return nil, but emit a descriptive slog.Error so
+// the cause is visible in logs. Callers that want "probe without crashing"
+// semantics can still check for nil explicitly; callers that chain methods
+// will still crash, but the preceding log line carries the real diagnostic.
+
+// captureSlog redirects the default slog logger into an in-memory buffer for
+// the duration of fn, then restores it. Returns the captured output.
+func captureSlog(fn func()) string {
+	var buf bytes.Buffer
+	orig := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError})))
+	defer slog.SetDefault(orig)
+	fn()
+	return buf.String()
+}
+
+// assertBoaError checks that captured output contains the expected substrings.
+func assertBoaError(t *testing.T, captured string, wantSubstrings ...string) {
+	t.Helper()
+	if !strings.Contains(captured, "boa.HookContext.GetParam") {
+		t.Errorf("slog output does not carry boa prefix: %q", captured)
+	}
+	for _, w := range wantSubstrings {
+		if !strings.Contains(captured, w) {
+			t.Errorf("slog output missing expected substring %q: %q", w, captured)
+		}
+	}
+}
+
+// TestGetParam_ForeignFieldLogsError: pass a pointer to a field in an
+// unrelated struct. GetParam must return nil AND emit a descriptive slog.Error
+// naming the likely causes.
+func TestGetParam_ForeignFieldLogsError(t *testing.T) {
+	type Params struct {
+		Name string `descr:"name" default:"default-name"`
+	}
+	type Other struct {
+		Foreign string
+	}
+	other := &Other{Foreign: "unrelated"}
+
+	var gotMirror Param
+
+	captured := captureSlog(func() {
+		cmd := (CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				gotMirror = ctx.GetParam(&other.Foreign)
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+		}).ToCobra()
+
+		cmd.SetArgs([]string{})
+		if err := Execute(cmd); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotMirror != nil {
+		t.Errorf("expected nil mirror for foreign field, got %p", gotMirror)
+	}
+	assertBoaError(t, captured, "does not belong to the parameters struct")
+}
+
+// TestGetParam_SameTypeDifferentInstanceLogsError: pass a pointer to a field
+// in a separately-allocated instance of the SAME Params type. Must return nil
+// and log the same descriptive error.
+func TestGetParam_SameTypeDifferentInstanceLogsError(t *testing.T) {
+	type Params struct {
+		Name string `descr:"name" default:"default-name"`
+	}
+	stranger := &Params{Name: "stranger"}
+
+	var gotMirror Param
+
+	captured := captureSlog(func() {
+		cmd := (CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				gotMirror = ctx.GetParam(&stranger.Name)
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+		}).ToCobra()
+
+		cmd.SetArgs([]string{})
+		if err := Execute(cmd); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotMirror != nil {
+		t.Errorf("expected nil mirror for foreign-instance-same-type lookup, got %p", gotMirror)
+	}
+	assertBoaError(t, captured, "does not belong to the parameters struct")
+}
+
+// TestGetParam_NilFieldPointerLogsError: passing untyped nil must return nil
+// and produce a descriptive log line, not a generic reflect crash.
+func TestGetParam_NilFieldPointerLogsError(t *testing.T) {
+	type Params struct {
+		Name string `descr:"name" default:"default-name"`
+	}
+
+	var gotMirror Param
+	gotMirror = nil // keep compiler happy when set inside closure
+
+	captured := captureSlog(func() {
+		cmd := (CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				gotMirror = ctx.GetParam(nil)
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+		}).ToCobra()
+
+		cmd.SetArgs([]string{})
+		if err := Execute(cmd); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotMirror != nil {
+		t.Errorf("expected nil mirror for nil fieldPtr, got %p", gotMirror)
+	}
+	assertBoaError(t, captured, "fieldPtr is nil")
+}
+
+// TestGetParam_NonPointerLogsError: passing a non-pointer value must return nil
+// with a descriptive message rather than crashing inside reflect.
+func TestGetParam_NonPointerLogsError(t *testing.T) {
+	type Params struct {
+		Name string `descr:"name" default:"default-name"`
+	}
+
+	var gotMirror Param
+
+	captured := captureSlog(func() {
+		cmd := (CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				gotMirror = ctx.GetParam("not-a-pointer")
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+		}).ToCobra()
+
+		cmd.SetArgs([]string{})
+		if err := Execute(cmd); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotMirror != nil {
+		t.Errorf("expected nil mirror for non-pointer fieldPtr, got %p", gotMirror)
+	}
+	assertBoaError(t, captured, "must be a pointer")
+}
+
+// TestGetParam_RegisteredFieldStillWorks is a paired sanity check: the happy
+// path still returns a non-nil mirror and the log stream should be empty.
+func TestGetParam_RegisteredFieldStillWorks(t *testing.T) {
+	type Params struct {
+		Name string `descr:"name" default:"default-name"`
+	}
+
+	var gotMirror Param
+
+	captured := captureSlog(func() {
+		cmd := (CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				gotMirror = ctx.GetParam(&p.Name)
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+		}).ToCobra()
+
+		cmd.SetArgs([]string{})
+		if err := Execute(cmd); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	})
+
+	if gotMirror == nil {
+		t.Errorf("registered field lookup returned nil")
+	}
+	if strings.Contains(captured, "boa.HookContext.GetParam") {
+		t.Errorf("unexpected boa GetParam error in log for happy path: %q", captured)
+	}
+}

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -1290,7 +1290,13 @@ func traverseAt(
 		// childPath is the declared-index path to this field from the root.
 		// Use declared index (i), not a visit counter, so ignored fields do not
 		// drift subsequent siblings.
-		childPath := append(append([]int(nil), path...), i)
+		//
+		// Single allocation: len(path)+1 explicitly sized. The old
+		// append(append([]int(nil), path...), i) form did two allocations per
+		// field visit, which matters during init of larger parameter trees.
+		childPath := make([]int, len(path)+1)
+		copy(childPath, path)
+		childPath[len(path)] = i
 
 		fieldAddr := rootValue.Field(i).Addr()
 		// check if field is a param
@@ -1340,9 +1346,12 @@ func traverseAt(
 				var ok bool
 				if param, ok = ctx.mirrorByPath[pathKey]; !ok {
 					param = newParam(&field, field.Type)
-					// Set prefix for named struct nesting
-					if prefix != "" {
-						if pm, ok := param.(*paramMeta); ok {
+					// Set prefix for named struct nesting, and stash the path
+					// key on the mirror so callers that have a *paramMeta can
+					// read it without scanning pathOrder.
+					if pm, ok := param.(*paramMeta); ok {
+						pm.pathKey = pathKey
+						if prefix != "" {
 							pm.flagPrefix = camelToKebabCase(prefix) + "-"
 							pm.envPrefix = kebabCaseToUpperSnakeCase(pm.flagPrefix[:len(pm.flagPrefix)-1]) + "_"
 						}
@@ -1605,17 +1614,15 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 					return fmt.Errorf("configfile tag on param %s: must be a string field", param.GetName())
 				}
 				// The target struct path is the parent of the configfile param's own path.
-				// Look up the param's path in the authoritative store, then strip the last index.
+				// Read it directly from paramMeta.pathKey (stashed during traverse) —
+				// no scan over pathOrder needed.
 				var targetPath fieldPath
-				for _, p := range ctx.pathOrder {
-					if ctx.mirrorByPath[p] == param {
-						if idx := strings.LastIndex(string(p), "."); idx >= 0 {
-							targetPath = p[:idx]
-						} else {
-							targetPath = ""
-						}
-						break
+				if pm, ok := param.(*paramMeta); ok {
+					if idx := strings.LastIndex(string(pm.pathKey), "."); idx >= 0 {
+						targetPath = pm.pathKey[:idx]
 					}
+					// If there's no dot, the configfile field lives at the root
+					// and its target path is the empty fieldPath — already set.
 				}
 				ctx.ConfigFiles = append(ctx.ConfigFiles, configFileEntry{
 					mirror:     param,

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -366,6 +366,13 @@ func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldP
 
 // splitPath parses a fieldPath string back into the []int index path form.
 // Accepts an empty path.
+//
+// splitPath is internal and its only legal input is a string previously emitted
+// by joinPath — which always produces digit segments separated by dots. A parse
+// error therefore represents a library-internal invariant violation, not user
+// input, and has no sensible recovery: silently substituting 0 would corrupt
+// downstream FieldByIndex lookups and surface as a confusing "mirror not found"
+// failure far from the real bug. Panic is the right response.
 func splitPath(p fieldPath) []int {
 	if p == "" {
 		return nil
@@ -373,7 +380,10 @@ func splitPath(p fieldPath) []int {
 	parts := strings.Split(string(p), ".")
 	out := make([]int, len(parts))
 	for i, s := range parts {
-		n, _ := strconv.Atoi(s)
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			panic(fmt.Errorf("boa: malformed fieldPath %q: segment %q is not a valid integer (this is a library bug, not user input)", p, s))
+		}
 		out[i] = n
 	}
 	return out

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -170,8 +170,44 @@ type Param interface {
 
 // configFileEntry tracks a configfile:"true" field and the struct it should load into.
 type configFileEntry struct {
-	mirror Param // the string param holding the file path
-	target any   // pointer to the struct to unmarshal into
+	mirror     Param     // the string param holding the file path
+	target     any       // pointer to the struct to unmarshal into
+	targetPath fieldPath // path from root to the target struct (empty for root)
+}
+
+// fieldPath is the dot-separated sequence of struct-field declaration indices
+// that locates a parameter from the root params struct. Example: "0.2.1" = root
+// field 0, its field 2, its field 1. Empty string means the root itself.
+//
+// Paths are the authoritative key for mirror storage — they are stable under
+// pointer-substruct reassignment (reflect.FieldByIndex walks through live
+// pointers at lookup time), debuggable, and support O(1) subtree operations
+// via string-prefix matching.
+type fieldPath string
+
+// joinPath serializes a []int index path to the canonical fieldPath string form.
+func joinPath(p []int) fieldPath {
+	if len(p) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, v := range p {
+		if i > 0 {
+			sb.WriteByte('.')
+		}
+		sb.WriteString(strconv.Itoa(v))
+	}
+	return fieldPath(sb.String())
+}
+
+// hasSubtreePrefix reports whether this path is prefix itself or a descendant of it.
+func (p fieldPath) hasSubtreePrefix(prefix fieldPath) bool {
+	if prefix == "" {
+		return true
+	}
+	s := string(p)
+	ps := string(prefix)
+	return s == ps || strings.HasPrefix(s, ps+".")
 }
 
 // preallocatedPtrInfo tracks a struct pointer field that was nil and got preallocated
@@ -180,17 +216,28 @@ type configFileEntry struct {
 // if none of its fields were explicitly set.
 type preallocatedPtrInfo struct {
 	ptrField reflect.Value // the pointer field in the parent struct (e.g., *DBConfig)
+	path     fieldPath     // path from root to this pointer field
 }
 
 type processingContext struct {
 	context.Context
-	RawAddrToMirror map[unsafe.Pointer]Param
-	// We need to keep track of raw params, so we can
-	// override the raw values with cli values in case
-	// the user may have mapped config files to the params
-	// as well - since the config file deserialization will
-	// not be aware of the raw values, and just overwrite them.
-	RawAddresses []unsafe.Pointer
+	// rootStructPtr is a pointer to the root parameters struct (e.g., *Params).
+	// All field paths are expressed relative to this root.
+	rootStructPtr any
+	// mirrorByPath is the authoritative mirror store, keyed by field-index path.
+	// Paths are stable under pointer-substruct reassignment and support efficient
+	// subtree queries via string-prefix matching.
+	mirrorByPath map[fieldPath]Param
+	// pathOrder preserves traverse insertion order for operations that need
+	// deterministic iteration (e.g., syncMirrors reads raw → mirror → raw in
+	// the order fields were discovered).
+	pathOrder []fieldPath
+	// addrToPath is a non-authoritative reverse index built during traverse.
+	// Its sole purpose is to support HookContext.GetParam(&params.Field),
+	// where users pass a Go field pointer and expect a mirror back. When the
+	// root parameters struct is reassigned mid-flight, this cache can be
+	// invalidated and rebuilt — mirrorByPath remains correct regardless.
+	addrToPath map[unsafe.Pointer]fieldPath
 	// ConfigFiles tracks all configfile:"true" fields and their target structs.
 	// Ordered: substruct entries first, root entry last (so root overrides inner).
 	ConfigFiles []configFileEntry
@@ -207,7 +254,10 @@ type processingContext struct {
 // tracking them in ctx.PreallocatedPtrs so they can be nil'd back after parsing if unused.
 // This must be called before the first traverse so that traverse discovers the child fields.
 // The list is built depth-first (innermost first) for correct cleanup ordering.
-func preallocateStructPtrs(ctx *processingContext, structPtr any) {
+//
+// path is the declared-index path from the root to the struct being walked, using
+// reflect.StructField.Index numbering. Ignored fields retain their slot.
+func preallocateStructPtrs(ctx *processingContext, structPtr any, path []int) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -215,9 +265,10 @@ func preallocateStructPtrs(ctx *processingContext, structPtr any) {
 		if isBoaIgnored(field) {
 			continue
 		}
+		childPath := append(append([]int(nil), path...), i)
 		// Recurse into non-pointer structs (they're always present)
 		if field.Type.Kind() == reflect.Struct && !isSupportedType(field.Type) {
-			preallocateStructPtrs(ctx, val.Field(i).Addr().Interface())
+			preallocateStructPtrs(ctx, val.Field(i).Addr().Interface(), childPath)
 			continue
 		}
 		// Preallocate nil struct pointer fields
@@ -226,14 +277,15 @@ func preallocateStructPtrs(ctx *processingContext, structPtr any) {
 			if fieldVal.IsNil() {
 				fieldVal.Set(reflect.New(field.Type.Elem()))
 				// Recurse into the newly allocated struct (inner pointers first)
-				preallocateStructPtrs(ctx, fieldVal.Interface())
+				preallocateStructPtrs(ctx, fieldVal.Interface(), childPath)
 				// Append after recursion so innermost entries come first
 				ctx.PreallocatedPtrs = append(ctx.PreallocatedPtrs, preallocatedPtrInfo{
 					ptrField: fieldVal,
+					path:     joinPath(childPath),
 				})
 			} else {
 				// Already non-nil (user pre-initialized) — still recurse for nested nil ptrs
-				preallocateStructPtrs(ctx, fieldVal.Interface())
+				preallocateStructPtrs(ctx, fieldVal.Interface(), childPath)
 			}
 			continue
 		}
@@ -258,9 +310,10 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 			anySet = true
 		}
 
-		// Walk the struct's fields and check if any mirror was explicitly set
+		// Walk the struct's fields and check if any mirror was explicitly set.
+		// Use the preallocation's recorded path so we resolve via mirrorByPath.
 		if !anySet {
-			collectAndCheck(ctx, structPtr, &anySet)
+			collectAndCheck(ctx, structPtr, splitPath(info.path), &anySet)
 		}
 
 		if !anySet {
@@ -278,8 +331,8 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 		}
 
 		if !anySet {
-			// Remove mirrors for all fields within this struct
-			removeMirrorsForStruct(ctx, structPtr)
+			// Remove mirrors for all fields within this subtree via path-prefix purge
+			removeMirrorsForSubtree(ctx, info.path)
 			// Nil the pointer
 			info.ptrField.Set(reflect.Zero(info.ptrField.Type()))
 		}
@@ -297,7 +350,7 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 //
 // Returns true if key-presence detection succeeded (JSON-compatible data).
 // Returns false for non-JSON data so the caller can fall back to snapshot comparison.
-func markConfigKeysPresent(ctx *processingContext, target any, rawData []byte) bool {
+func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldPath, rawData []byte) bool {
 	if len(ctx.PreallocatedPtrs) == 0 || len(rawData) == 0 {
 		return false
 	}
@@ -307,8 +360,23 @@ func markConfigKeysPresent(ctx *processingContext, target any, rawData []byte) b
 		return false // not JSON-compatible; caller should use snapshot fallback
 	}
 	// Walk the target struct type and match keys against preallocated struct ptrs
-	markConfigKeysPresentInStruct(ctx, target, topLevel)
+	markConfigKeysPresentInStruct(ctx, target, topLevel, splitPath(targetPath))
 	return true
+}
+
+// splitPath parses a fieldPath string back into the []int index path form.
+// Accepts an empty path.
+func splitPath(p fieldPath) []int {
+	if p == "" {
+		return nil
+	}
+	parts := strings.Split(string(p), ".")
+	out := make([]int, len(parts))
+	for i, s := range parts {
+		n, _ := strconv.Atoi(s)
+		out[i] = n
+	}
+	return out
 }
 
 // jsonFieldKey returns the key that encoding/json would use for a struct field.
@@ -345,7 +413,7 @@ func jsonKeyLookup(keys map[string]json.RawMessage, target string) (json.RawMess
 	return nil, false
 }
 
-func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]json.RawMessage) {
+func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]json.RawMessage, path []int) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -353,6 +421,7 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 		if isBoaIgnored(field) {
 			continue
 		}
+		childPath := append(append([]int(nil), path...), i)
 		jsonKey := jsonFieldKey(field)
 		rawVal, keyPresent := jsonKeyLookup(keys, jsonKey)
 		if !keyPresent {
@@ -367,7 +436,7 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 			markStructPtrPresentByConfig(ctx, fieldVal.Interface())
 			var subKeys map[string]json.RawMessage
 			if json.Unmarshal(rawVal, &subKeys) == nil && len(subKeys) > 0 {
-				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subKeys)
+				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subKeys, childPath)
 			}
 			continue
 		}
@@ -375,14 +444,13 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 		if field.Type.Kind() == reflect.Struct && !isSupportedType(field.Type) {
 			var subKeys map[string]json.RawMessage
 			if json.Unmarshal(rawVal, &subKeys) == nil {
-				markConfigKeysPresentInStruct(ctx, fieldVal.Addr().Interface(), subKeys)
+				markConfigKeysPresentInStruct(ctx, fieldVal.Addr().Interface(), subKeys, childPath)
 			}
 			continue
 		}
 		// Leaf field present in config — mark its mirror
 		if isSupportedType(field.Type) {
-			addr := fieldVal.Addr().UnsafePointer()
-			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+			if mirror, ok := ctx.mirrorByPath[joinPath(childPath)]; ok {
 				if pm, isPM := mirror.(*paramMeta); isPM {
 					pm.setByConfig = true
 				}
@@ -417,7 +485,7 @@ func markConfigChangedStructs(ctx *processingContext, snapshots []reflect.Value)
 		}
 		current := info.ptrField.Elem()
 		if !reflect.DeepEqual(current.Interface(), snapshots[i].Interface()) {
-			markAllMirrorsInStruct(ctx, info.ptrField.Interface())
+			markAllMirrorsInSubtree(ctx, info.ptrField.Interface(), splitPath(info.path))
 		}
 	}
 }
@@ -434,12 +502,17 @@ func markStructPtrPresentByConfig(ctx *processingContext, structPtr any) {
 	ctx.ConfigPresentPtrs[addr] = true
 }
 
-// markAllMirrorsInStruct marks mirrors in this struct as set by config.
-// It recurses into non-pointer structs but STOPS at pointer-to-struct boundaries.
-// Pointer-to-struct fields are handled by key-presence recursion in
-// markConfigKeysPresentInStruct, which only marks nested ptr structs if the
-// config data actually mentions them.
-func markAllMirrorsInStruct(ctx *processingContext, structPtr any) {
+// markAllMirrorsInSubtree marks every mirror within the given subtree as set by config.
+// The subtree is identified by its path from the root (empty path == entire root).
+// Only direct-descendant mirrors are marked; nested pointer-to-struct boundaries are
+// handled separately by key-presence recursion in markConfigKeysPresentInStruct.
+//
+// We iterate mirrorByPath looking for entries whose path starts with prefix and does
+// NOT cross a pointer-struct boundary further down (i.e., they're the immediate
+// flat-descendant leaves reachable by struct-walking without ptr indirection).
+// For simplicity — and to match the prior reflect-walking semantics — we walk the
+// actual struct at `structPtr` and compute child paths to look up.
+func markAllMirrorsInSubtree(ctx *processingContext, structPtr any, path []int) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -447,10 +520,10 @@ func markAllMirrorsInStruct(ctx *processingContext, structPtr any) {
 		if isBoaIgnored(field) {
 			continue
 		}
+		childPath := append(append([]int(nil), path...), i)
 		fieldVal := val.Field(i)
 		if isSupportedType(field.Type) {
-			addr := fieldVal.Addr().UnsafePointer()
-			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+			if mirror, ok := ctx.mirrorByPath[joinPath(childPath)]; ok {
 				if pm, isPM := mirror.(*paramMeta); isPM {
 					pm.setByConfig = true
 				}
@@ -458,7 +531,7 @@ func markAllMirrorsInStruct(ctx *processingContext, structPtr any) {
 			continue
 		}
 		if field.Type.Kind() == reflect.Struct {
-			markAllMirrorsInStruct(ctx, fieldVal.Addr().Interface())
+			markAllMirrorsInSubtree(ctx, fieldVal.Addr().Interface(), childPath)
 			continue
 		}
 		// Do NOT recurse into pointer-to-struct fields here.
@@ -468,7 +541,8 @@ func markAllMirrorsInStruct(ctx *processingContext, structPtr any) {
 
 // collectAndCheck walks a struct's fields and checks if any mirror was explicitly set
 // by the user (CLI, env var, or config file). Default values alone don't count.
-func collectAndCheck(ctx *processingContext, structPtr any, anySet *bool) {
+// path is the path-from-root of structPtr (empty for root).
+func collectAndCheck(ctx *processingContext, structPtr any, path []int, anySet *bool) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -479,10 +553,10 @@ func collectAndCheck(ctx *processingContext, structPtr any, anySet *bool) {
 		if isBoaIgnored(field) {
 			continue
 		}
+		childPath := append(append([]int(nil), path...), i)
 		fieldVal := val.Field(i)
 		if isSupportedType(field.Type) {
-			addr := fieldVal.Addr().UnsafePointer()
-			if mirror, ok := ctx.RawAddrToMirror[addr]; ok {
+			if mirror, ok := ctx.mirrorByPath[joinPath(childPath)]; ok {
 				pm, isPM := mirror.(*paramMeta)
 				if mirror.wasSetOnCli() || mirror.wasSetByEnv() {
 					*anySet = true
@@ -497,49 +571,40 @@ func collectAndCheck(ctx *processingContext, structPtr any, anySet *bool) {
 		}
 		// Recurse into non-pointer structs
 		if field.Type.Kind() == reflect.Struct {
-			collectAndCheck(ctx, fieldVal.Addr().Interface(), anySet)
+			collectAndCheck(ctx, fieldVal.Addr().Interface(), childPath, anySet)
 			continue
 		}
 		// Recurse into non-nil pointer structs
 		if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
-			collectAndCheck(ctx, fieldVal.Interface(), anySet)
+			collectAndCheck(ctx, fieldVal.Interface(), childPath, anySet)
 		}
 	}
 }
 
-// removeMirrorsForStruct removes all mirrors belonging to fields within the given struct
-// from the processing context, preventing dangling unsafe pointers after the struct is nil'd.
-func removeMirrorsForStruct(ctx *processingContext, structPtr any) {
-	val := reflect.ValueOf(structPtr).Elem()
-	typ := val.Type()
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if isBoaIgnored(field) {
-			continue
-		}
-		fieldVal := val.Field(i)
-		if isSupportedType(field.Type) {
-			addr := fieldVal.Addr().UnsafePointer()
-			delete(ctx.RawAddrToMirror, addr)
-			// Remove from RawAddresses slice
-			for j, a := range ctx.RawAddresses {
-				if a == addr {
-					ctx.RawAddresses = append(ctx.RawAddresses[:j], ctx.RawAddresses[j+1:]...)
-					break
-				}
-			}
-			continue
-		}
-		// Recurse into non-pointer structs
-		if field.Type.Kind() == reflect.Struct {
-			removeMirrorsForStruct(ctx, fieldVal.Addr().Interface())
-			continue
-		}
-		// Recurse into non-nil pointer structs
-		if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
-			removeMirrorsForStruct(ctx, fieldVal.Interface())
+// removeMirrorsForSubtree removes all mirrors whose path is equal to or descends from
+// the given prefix path. Uses string-prefix matching on the authoritative path store;
+// no struct walking required.
+func removeMirrorsForSubtree(ctx *processingContext, prefix fieldPath) {
+	// Purge mirrorByPath
+	for p := range ctx.mirrorByPath {
+		if p.hasSubtreePrefix(prefix) {
+			delete(ctx.mirrorByPath, p)
 		}
 	}
+	// Rebuild pathOrder without the removed entries
+	kept := ctx.pathOrder[:0]
+	for _, p := range ctx.pathOrder {
+		if _, still := ctx.mirrorByPath[p]; still {
+			kept = append(kept, p)
+		}
+	}
+	// Zero out tail references so GC can reclaim the removed fieldPath strings
+	for i := len(kept); i < len(ctx.pathOrder); i++ {
+		ctx.pathOrder[i] = ""
+	}
+	ctx.pathOrder = kept
+	// Invalidate reverse address index — addresses inside the removed subtree are now stale
+	ctx.addrToPath = nil
 }
 
 func parseEnv(ctx *processingContext, structPtr any) error {
@@ -1159,9 +1224,28 @@ func isBoaIgnored(field reflect.StructField) bool {
 		slices.Contains(boaTags, "-")
 }
 
+// traverse is the public-facing entrypoint; it walks from the root params struct
+// starting with an empty path. It accepts variadic prefix strings for backward
+// compatibility with existing call sites that sometimes preload a name prefix.
 func traverse(
 	ctx *processingContext,
 	structPtr any,
+	fParam func(param Param, paramFieldName string, tags reflect.StructTag) error,
+	fStruct func(structPtr any) error,
+	prefixParts ...string,
+) error {
+	return traverseAt(ctx, structPtr, nil, fParam, fStruct, prefixParts...)
+}
+
+// traverseAt walks the struct tree while carrying the declared-index path from
+// the root. The path is what identifies each leaf mirror in mirrorByPath.
+// Ignored fields retain their declared index slot; only the loop variable i is
+// used for path construction (never a visit counter), so interleaved ignored
+// fields cannot drift the key.
+func traverseAt(
+	ctx *processingContext,
+	structPtr any,
+	path []int,
 	fParam func(param Param, paramFieldName string, tags reflect.StructTag) error,
 	fStruct func(structPtr any) error,
 	prefixParts ...string,
@@ -1193,6 +1277,11 @@ func traverse(
 			continue
 		}
 
+		// childPath is the declared-index path to this field from the root.
+		// Use declared index (i), not a visit counter, so ignored fields do not
+		// drift subsequent siblings.
+		childPath := append(append([]int(nil), path...), i)
+
 		fieldAddr := rootValue.Field(i).Addr()
 		// check if field is a param
 		param, isParam := fieldAddr.Interface().(Param)
@@ -1213,7 +1302,7 @@ func traverse(
 				if !field.Anonymous {
 					childPrefix = prefix + field.Name
 				}
-				if err := traverse(ctx, fieldAddr.Interface(), fParam, fStruct, childPrefix); err != nil {
+				if err := traverseAt(ctx, fieldAddr.Interface(), childPath, fParam, fStruct, childPrefix); err != nil {
 					return err
 				}
 				continue
@@ -1226,20 +1315,20 @@ func traverse(
 					if !field.Anonymous {
 						childPrefix = prefix + field.Name
 					}
-					if err := traverse(ctx, fieldAddr.Elem().Interface(), fParam, fStruct, childPrefix); err != nil {
+					if err := traverseAt(ctx, fieldAddr.Elem().Interface(), childPath, fParam, fStruct, childPrefix); err != nil {
 						return err
 					}
 				}
 				continue
 			}
 
-			// For raw fields, we store parameter mirrors in the processing context
+			// For raw fields, store parameter mirrors keyed by field-index path.
 			if isSupportedType(field.Type) {
 
 				// check if we already have a mirror for this field
-				addr := fieldAddr.UnsafePointer()
+				pathKey := joinPath(childPath)
 				var ok bool
-				if param, ok = ctx.RawAddrToMirror[addr]; !ok {
+				if param, ok = ctx.mirrorByPath[pathKey]; !ok {
 					param = newParam(&field, field.Type)
 					// Set prefix for named struct nesting
 					if prefix != "" {
@@ -1248,8 +1337,13 @@ func traverse(
 							pm.envPrefix = kebabCaseToUpperSnakeCase(pm.flagPrefix[:len(pm.flagPrefix)-1]) + "_"
 						}
 					}
-					ctx.RawAddresses = append(ctx.RawAddresses, addr)
-					ctx.RawAddrToMirror[addr] = param
+					ctx.pathOrder = append(ctx.pathOrder, pathKey)
+					ctx.mirrorByPath[pathKey] = param
+					// Maintain the reverse address index for HookContext.GetParam(&field).
+					// This is a non-authoritative cache — mirrorByPath is the source of truth.
+					if ctx.addrToPath != nil {
+						ctx.addrToPath[fieldAddr.UnsafePointer()] = pathKey
+					}
 				}
 
 				if fParam != nil {
@@ -1290,16 +1384,18 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 	}
 
 	ctx := &processingContext{
-		Context:         context.Background(), // prepare to override later?
-		RawAddrToMirror: map[unsafe.Pointer]Param{},
-		RawAddresses:    []unsafe.Pointer{},
+		Context:       context.Background(), // prepare to override later?
+		rootStructPtr: b.Params,
+		mirrorByPath:  map[fieldPath]Param{},
+		pathOrder:     []fieldPath{},
+		addrToPath:    map[unsafe.Pointer]fieldPath{},
 	}
 
 	// Preallocate nil struct pointer fields so traverse can discover their children.
 	// This must happen before the first traverse and before init hooks so users can
 	// access fields like &params.DB.Port in InitFunc/InitFuncCtx.
 	if b.Params != nil {
-		preallocateStructPtrs(ctx, b.Params)
+		preallocateStructPtrs(ctx, b.Params, nil)
 	}
 
 	// build mirrors
@@ -1322,7 +1418,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			}
 			// context-aware interface
 			if toInitCtx, ok := b.Params.(CfgStructInitCtx); ok {
-				hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+				hookCtx := newHookContext(ctx)
 				err := toInitCtx.InitCtx(hookCtx)
 				if err != nil {
 					return fmt.Errorf("error in CfgStructInitCtx.InitCtx(): %w", err)
@@ -1345,7 +1441,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 
 	// if we have a context-aware init function, call it
 	if b.InitFuncCtx != nil {
-		hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+		hookCtx := newHookContext(ctx)
 		err := b.InitFuncCtx(hookCtx, b.Params, cmd)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error in InitFuncCtx: %w", err)
@@ -1498,9 +1594,23 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				if param.GetType().Kind() != reflect.String {
 					return fmt.Errorf("configfile tag on param %s: must be a string field", param.GetName())
 				}
+				// The target struct path is the parent of the configfile param's own path.
+				// Look up the param's path in the authoritative store, then strip the last index.
+				var targetPath fieldPath
+				for _, p := range ctx.pathOrder {
+					if ctx.mirrorByPath[p] == param {
+						if idx := strings.LastIndex(string(p), "."); idx >= 0 {
+							targetPath = p[:idx]
+						} else {
+							targetPath = ""
+						}
+						break
+					}
+				}
 				ctx.ConfigFiles = append(ctx.ConfigFiles, configFileEntry{
-					mirror: param,
-					target: currentStructPtr,
+					mirror:     param,
+					target:     currentStructPtr,
+					targetPath: targetPath,
 				})
 			}
 
@@ -1589,7 +1699,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			}
 		}
 		if postCreateCtx, ok := b.Params.(CfgStructPostCreateCtx); ok {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			if err := postCreateCtx.PostCreateCtx(hookCtx); err != nil {
 				return nil, nil, fmt.Errorf("error in CfgStructPostCreateCtx.PostCreateCtx(): %w", err)
 			}
@@ -1601,7 +1711,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			}
 		}
 		if b.PostCreateFuncCtx != nil {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			err := b.PostCreateFuncCtx(hookCtx, b.Params, cmd)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error in PostCreateFuncCtx: %w", err)
@@ -1671,8 +1781,9 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// the raw bytes for key presence — this lets us detect config-file writes
 			// even when the value equals Go's zero value or the field's default.
 			type configLoadResult struct {
-				target  any
-				rawData []byte
+				target     any
+				targetPath fieldPath
+				rawData    []byte
 			}
 			var configResults []configLoadResult
 
@@ -1695,7 +1806,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, rawData: rawData})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData})
 						}
 					}
 				}
@@ -1708,7 +1819,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, rawData: rawData})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData})
 						}
 					}
 				}
@@ -1721,7 +1832,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// For non-JSON formats, fall back to snapshot comparison.
 			allDetected := true
 			for _, cr := range configResults {
-				if !markConfigKeysPresent(ctx, cr.target, cr.rawData) {
+				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData) {
 					allDetected = false
 				}
 			}
@@ -1749,7 +1860,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				}
 				// context-aware interface
 				if s, ok := innerParams.(CfgStructPreValidateCtx); ok {
-					hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+					hookCtx := newHookContext(ctx)
 					err := s.PreValidateCtx(hookCtx)
 					if err != nil {
 						return fmt.Errorf("error in PreValidateCtx: %w", err)
@@ -1771,7 +1882,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 
 			// if we have a context-aware pre-validate function, call it
 			if b.PreValidateFuncCtx != nil {
-				hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+				hookCtx := newHookContext(ctx)
 				err := b.PreValidateFuncCtx(hookCtx, b.Params, cmd, args)
 				if err != nil {
 					return fmt.Errorf("error in PreValidateFuncCtx: %w", err)
@@ -1797,7 +1908,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				}
 				// context-aware interface
 				if preExecuteCtx, ok := innerParams.(CfgStructPreExecuteCtx); ok {
-					hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+					hookCtx := newHookContext(ctx)
 					err := preExecuteCtx.PreExecuteCtx(hookCtx)
 					if err != nil {
 						return fmt.Errorf("error in PreExecuteCtx: %w", err)
@@ -1819,7 +1930,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 
 			// if we have a context-aware pre-execute function, call it
 			if b.PreExecuteFuncCtx != nil {
-				hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+				hookCtx := newHookContext(ctx)
 				err := b.PreExecuteFuncCtx(hookCtx, b.Params, cmd, args)
 				if err != nil {
 					return fmt.Errorf("error in PreExecuteFuncCtx: %w", err)
@@ -1874,7 +1985,7 @@ func (b Cmd) toCobraImpl() *cobra.Command {
 		}
 	} else if b.RunFuncCtx != nil {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			b.RunFuncCtx(hookCtx, cmd, args)
 			return nil
 		}
@@ -1888,7 +1999,7 @@ func (b Cmd) toCobraImpl() *cobra.Command {
 		}
 	} else if b.RunFuncCtxE != nil {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			err := b.RunFuncCtxE(hookCtx, cmd, args)
 			if err != nil && !IsUserInputError(err) {
 				return &runFuncError{Err: err}
@@ -1932,7 +2043,7 @@ func (b Cmd) toCobraImplE() (*cobra.Command, error) {
 		}
 	} else if b.RunFuncCtxE != nil {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			return b.RunFuncCtxE(hookCtx, cmd, args)
 		}
 	} else if b.RunFunc != nil {
@@ -1944,7 +2055,7 @@ func (b Cmd) toCobraImplE() (*cobra.Command, error) {
 	} else if b.RunFuncCtx != nil {
 		// Wrap non-E variant to return nil (no error)
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			hookCtx := &HookContext{rawAddrToMirror: ctx.RawAddrToMirror}
+			hookCtx := newHookContext(ctx)
 			b.RunFuncCtx(hookCtx, cmd, args)
 			return nil
 		}
@@ -1967,42 +2078,125 @@ func (b Cmd) toCobraImplE() (*cobra.Command, error) {
 	return cmd, nil
 }
 
+// resolveFieldValue walks from the root params struct to the field at the given
+// declared-index path and returns an addressable reflect.Value for that field.
+// Returns (zero, false) if any intermediate pointer-to-struct is nil (which can
+// happen after cleanupPreallocatedPtrs nils an unused substruct).
+func (ctx *processingContext) resolveFieldValue(path fieldPath) (reflect.Value, bool) {
+	if ctx.rootStructPtr == nil {
+		return reflect.Value{}, false
+	}
+	v := reflect.ValueOf(ctx.rootStructPtr).Elem()
+	idx := splitPath(path)
+	for _, i := range idx {
+		for v.Kind() == reflect.Ptr {
+			if v.IsNil() {
+				return reflect.Value{}, false
+			}
+			v = v.Elem()
+		}
+		if v.Kind() != reflect.Struct {
+			return reflect.Value{}, false
+		}
+		if i >= v.NumField() {
+			return reflect.Value{}, false
+		}
+		v = v.Field(i)
+	}
+	// For the final value, if it is a pointer-to-struct we do NOT auto-deref:
+	// mirror types may themselves be pointers (e.g., *url.URL), and pointer-field
+	// semantics are handled by syncPointerField.
+	return v, true
+}
+
+// rebuildAddrToPath walks the current live struct tree (starting from rootStructPtr)
+// and rebuilds the reverse address index. Called on demand when the cache has been
+// invalidated (e.g., after a subtree removal).
+func (ctx *processingContext) rebuildAddrToPath() {
+	ctx.addrToPath = map[unsafe.Pointer]fieldPath{}
+	for _, p := range ctx.pathOrder {
+		v, ok := ctx.resolveFieldValue(p)
+		if !ok || !v.CanAddr() {
+			continue
+		}
+		ctx.addrToPath[v.Addr().UnsafePointer()] = p
+	}
+}
+
+// findPathByAddr walks the live struct tree and searches for a leaf whose address
+// matches. Used as a fallback when the reverse index is stale (e.g., a substruct
+// was reassigned by user code).
+func (ctx *processingContext) findPathByAddr(addr unsafe.Pointer) (fieldPath, bool) {
+	for _, p := range ctx.pathOrder {
+		v, ok := ctx.resolveFieldValue(p)
+		if !ok || !v.CanAddr() {
+			continue
+		}
+		if v.Addr().UnsafePointer() == addr {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// reinterpretAs returns the raw field value viewed as the target type, without
+// copying. This supports type aliases (e.g., a MyString field seen as string) by
+// taking the field's address and reconstructing a Value at the same memory with
+// the target type. If the types already match, the input is returned unchanged.
+//
+// This is the one legitimate use of unsafe in the sync path — cobra's flag system
+// only knows underlying types, so mirror storage and mirror → raw writes must go
+// through the underlying view of the memory.
+func reinterpretAs(rawFieldVal reflect.Value, target reflect.Type) reflect.Value {
+	if rawFieldVal.Type() == target {
+		return rawFieldVal
+	}
+	return reflect.NewAt(target, rawFieldVal.Addr().UnsafePointer()).Elem()
+}
+
 func syncMirrors(ctx *processingContext) {
 	// 1. First, copy non-zero values from the raw fields -> mirrors as injected values.
 	// 2. Then copy back cli & env set values to the raw fields
 
-	for _, rawAddr := range ctx.RawAddresses {
-		mirror := ctx.RawAddrToMirror[rawAddr]
+	for _, p := range ctx.pathOrder {
+		mirror, ok := ctx.mirrorByPath[p]
+		if !ok {
+			continue
+		}
+		rawFieldVal, resolved := ctx.resolveFieldValue(p)
+		if !resolved {
+			// The substruct housing this field has been nil'd out by cleanup — skip.
+			continue
+		}
 
 		// Check if this is a pointer field (e.g., *string, *int)
 		pm, isParamMeta := mirror.(*paramMeta)
 		if isParamMeta && pm.isPointer {
-			syncPointerField(rawAddr, mirror, pm)
+			// Reinterpret as pointer-to-underlying-type so type aliases round-trip
+			ptrView := reinterpretAs(rawFieldVal, reflect.PointerTo(mirror.GetType()))
+			syncPointerField(ptrView, mirror)
 			continue
 		}
 
-		// Create a reflect.Value pointing to the raw field via its stored address
-		ptrToRawValue := reflect.NewAt(mirror.GetType(), rawAddr)
+		// Reinterpret as the underlying type (matters for type aliases)
+		underlying := reinterpretAs(rawFieldVal, mirror.GetType())
 
-		if !mirror.wasSetOnCli() && !mirror.wasSetByEnv() && !ptrToRawValue.Elem().IsZero() {
-			mirror.injectValuePtr(ptrToRawValue.Interface())
+		if !mirror.wasSetOnCli() && !mirror.wasSetByEnv() && !underlying.IsZero() {
+			mirror.injectValuePtr(underlying.Addr().Interface())
 		}
 
-		if mirror.wasSetOnCli() || mirror.wasSetByEnv() || (mirror.HasValue() && ptrToRawValue.Elem().IsZero()) {
+		if mirror.wasSetOnCli() || mirror.wasSetByEnv() || (mirror.HasValue() && underlying.IsZero()) {
 			mirrorValue := reflect.ValueOf(mirror.valuePtrF()).Elem()
-
-			// Get the element that the pointer points to
-			rawValue := ptrToRawValue.Elem()
 
 			// Skip if types don't match (e.g., string vs *url.URL before conversion)
 			// This allows syncing to work before and after validation/conversion
-			if !mirrorValue.Type().AssignableTo(rawValue.Type()) {
+			if !mirrorValue.Type().AssignableTo(underlying.Type()) {
 				continue
 			}
 
 			// Make sure the destination is settable
-			if rawValue.CanSet() {
-				rawValue.Set(mirrorValue)
+			if underlying.CanSet() {
+				underlying.Set(mirrorValue)
 			} else {
 				panic(fmt.Errorf("could not set value for parameter %s", mirror.GetName()))
 			}
@@ -2011,14 +2205,9 @@ func syncMirrors(ctx *processingContext) {
 }
 
 // syncPointerField handles bidirectional sync for pointer fields like *string, *int.
-// rawAddr points to the pointer field itself (e.g., the *string field in the user's struct).
-// The mirror stores the value type (string), while the raw field is a pointer (*string).
-func syncPointerField(rawAddr unsafe.Pointer, mirror Param, _ *paramMeta) {
-	// rawAddr points to the *string field. reflect.NewAt creates a **string pointing at it.
-	ptrType := reflect.PointerTo(mirror.GetType()) // e.g., *string
-	rawFieldPtr := reflect.NewAt(ptrType, rawAddr)  // **string pointing at the field
-	rawFieldVal := rawFieldPtr.Elem()                // the *string field value itself
-
+// rawFieldVal is the *string field value itself (an addressable reflect.Value of
+// pointer kind). The mirror stores the element type (string).
+func syncPointerField(rawFieldVal reflect.Value, mirror Param) {
 	// Raw → Mirror: if the user's pointer is non-nil, inject the pointed-to value
 	if !mirror.wasSetOnCli() && !mirror.wasSetByEnv() && !rawFieldVal.IsNil() {
 		// rawFieldVal.Interface() is *string — same type cobra uses

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -238,6 +238,12 @@ type processingContext struct {
 	// root parameters struct is reassigned mid-flight, this cache can be
 	// invalidated and rebuilt — mirrorByPath remains correct regardless.
 	addrToPath map[unsafe.Pointer]fieldPath
+	// walkFallbackCount / cacheRebuildCount are instrumentation counters for
+	// tests that need to assert whether a GetParam call hit the fast path or
+	// fell through to the slower fallback walk / cache rebuild. Incremented
+	// unconditionally — cheap, zero-cost for production code.
+	walkFallbackCount int
+	cacheRebuildCount int
 	// ConfigFiles tracks all configfile:"true" fields and their target structs.
 	// Ordered: substruct entries first, root entry last (so root overrides inner).
 	ConfigFiles []configFileEntry
@@ -2130,6 +2136,7 @@ func (ctx *processingContext) resolveFieldValue(path fieldPath) (reflect.Value, 
 // and rebuilds the reverse address index. Called on demand when the cache has been
 // invalidated (e.g., after a subtree removal).
 func (ctx *processingContext) rebuildAddrToPath() {
+	ctx.cacheRebuildCount++
 	ctx.addrToPath = map[unsafe.Pointer]fieldPath{}
 	for _, p := range ctx.pathOrder {
 		v, ok := ctx.resolveFieldValue(p)
@@ -2144,6 +2151,7 @@ func (ctx *processingContext) rebuildAddrToPath() {
 // matches. Used as a fallback when the reverse index is stale (e.g., a substruct
 // was reassigned by user code).
 func (ctx *processingContext) findPathByAddr(addr unsafe.Pointer) (fieldPath, bool) {
+	ctx.walkFallbackCount++
 	for _, p := range ctx.pathOrder {
 		v, ok := ctx.resolveFieldValue(p)
 		if !ok || !v.CanAddr() {

--- a/pkg/boa/multi_substruct_test.go
+++ b/pkg/boa/multi_substruct_test.go
@@ -1,0 +1,217 @@
+package boa
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestMultipleSubstructsOfSameType_NoInterference exercises the case where a
+// root params struct holds two fields of the same substruct type (a common
+// pattern — e.g., a read-write and a read-only database connection config).
+// Each instance gets its own prefix and its own mirrors; configuring one must
+// not affect the other, even though their Go types are identical.
+//
+// Shape:
+//
+//	type Params struct {
+//	    RW DB  // flags: --rw-host, --rw-port, paths "0.0", "0.1"
+//	    RO DB  // flags: --ro-host, --ro-port, paths "1.0", "1.1"
+//	}
+//
+// The test proves:
+//   - Each substruct instance produces its own distinct paramMeta.
+//   - Alternatives and custom validators set on one instance's mirror are
+//     invisible to the other's.
+//   - CLI values for --rw-host and --ro-host land in their respective fields.
+func TestMultipleSubstructsOfSameType_NoInterference(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host"`
+		Port int    `descr:"port" default:"0"`
+	}
+	type Params struct {
+		RW DB
+		RO DB
+	}
+
+	var (
+		rwHostMirror   Param
+		roHostMirror   Param
+		rwValidations  int
+		roValidations  int
+		finalRWHost    string
+		finalROHost    string
+	)
+
+	makeTree := func() CmdT[Params] {
+		return CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				rwHostMirror = ctx.GetParam(&p.RW.Host)
+				roHostMirror = ctx.GetParam(&p.RO.Host)
+
+				// Different strict alternatives sets.
+				rwHostMirror.SetAlternatives([]string{"rw-a", "rw-b"})
+				roHostMirror.SetAlternatives([]string{"ro-a", "ro-b"})
+
+				// Different custom validators with observable side effects.
+				rwHostMirror.SetCustomValidator(func(v any) error {
+					rwValidations++
+					if !strings.HasPrefix(v.(string), "rw-") {
+						return fmt.Errorf("RW host must have 'rw-' prefix")
+					}
+					return nil
+				})
+				roHostMirror.SetCustomValidator(func(v any) error {
+					roValidations++
+					if !strings.HasPrefix(v.(string), "ro-") {
+						return fmt.Errorf("RO host must have 'ro-' prefix")
+					}
+					return nil
+				})
+				return nil
+			},
+			RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+				finalRWHost = p.RW.Host
+				finalROHost = p.RO.Host
+			},
+		}
+	}
+
+	reset := func() {
+		rwHostMirror, roHostMirror = nil, nil
+		rwValidations, roValidations = 0, 0
+		finalRWHost, finalROHost = "", ""
+	}
+
+	// --- Distinct mirror instances for the two substructs ---
+	reset()
+	tree := makeTree()
+	if err := tree.RunArgsE([]string{"--rw-host", "rw-a", "--ro-host", "ro-b"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if rwHostMirror == nil || roHostMirror == nil {
+		t.Fatalf("mirror fetch returned nil: rw=%p ro=%p", rwHostMirror, roHostMirror)
+	}
+	if rwHostMirror == roHostMirror {
+		t.Errorf("two substructs of the same type share a single mirror instance: rw=ro=%p", rwHostMirror)
+	}
+
+	// --- Alternatives did not bleed across instances ---
+	rwAlts := rwHostMirror.GetAlternatives()
+	roAlts := roHostMirror.GetAlternatives()
+	if !slices.Equal(rwAlts, []string{"rw-a", "rw-b"}) {
+		t.Errorf("RW alternatives clobbered: %v", rwAlts)
+	}
+	if !slices.Equal(roAlts, []string{"ro-a", "ro-b"}) {
+		t.Errorf("RO alternatives clobbered: %v", roAlts)
+	}
+
+	// --- Each validator fires exactly once for its own field, not the other ---
+	if rwValidations != 1 {
+		t.Errorf("rwValidations = %d, want 1", rwValidations)
+	}
+	if roValidations != 1 {
+		t.Errorf("roValidations = %d, want 1", roValidations)
+	}
+
+	// --- CLI values landed in their respective fields ---
+	if finalRWHost != "rw-a" {
+		t.Errorf("finalRWHost = %q, want 'rw-a'", finalRWHost)
+	}
+	if finalROHost != "ro-b" {
+		t.Errorf("finalROHost = %q, want 'ro-b'", finalROHost)
+	}
+
+	// --- Cross-substruct rejection: feeding RW's alt to RO should fail strict-alts ---
+	reset()
+	err := makeTree().RunArgsE([]string{"--rw-host", "rw-a", "--ro-host", "rw-a"})
+	if err == nil {
+		t.Errorf("RO should reject 'rw-a' (not in its strict alts list)")
+	}
+
+	// --- Cross-substruct rejection via the custom validator prefix check ---
+	// Pick a value that passes strict-alts for RO but fails its custom validator.
+	reset()
+	makeTree2 := makeTree
+	// Replace RO's alternatives with a value that's NOT a valid rw-/ro- prefix to
+	// isolate the custom validator's contribution.
+	_ = makeTree2 // keep compiler happy if the logic below changes
+	err = makeTree().RunArgsE([]string{"--rw-host", "rw-a", "--ro-host", "ro-a"})
+	if err != nil {
+		t.Errorf("ro-a should be accepted by both RO alts and RO validator, got: %v", err)
+	}
+}
+
+// TestMultipleSubstructPointersOfSameType_NoInterference is the pointer-field
+// variant: the two substruct fields are *DB instead of DB. Boa preallocates
+// both on build, each gets its own mirrors and its own heap allocation. The
+// same isolation invariants must hold.
+func TestMultipleSubstructPointersOfSameType_NoInterference(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host"`
+	}
+	type Params struct {
+		RW *DB
+		RO *DB
+	}
+
+	var (
+		rwHostMirror Param
+		roHostMirror Param
+		finalRWHost  string
+		finalROHost  string
+	)
+
+	makeTree := func() CmdT[Params] {
+		return CmdT[Params]{
+			Use: "test",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				// Both substructs are preallocated by boa before init fires, so
+				// &p.RW.Host and &p.RO.Host are both safe to address here.
+				rwHostMirror = ctx.GetParam(&p.RW.Host)
+				roHostMirror = ctx.GetParam(&p.RO.Host)
+				rwHostMirror.SetAlternatives([]string{"rw-only"})
+				roHostMirror.SetAlternatives([]string{"ro-only"})
+				return nil
+			},
+			RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+				if p.RW != nil {
+					finalRWHost = p.RW.Host
+				}
+				if p.RO != nil {
+					finalROHost = p.RO.Host
+				}
+			},
+		}
+	}
+
+	// Happy path: each substruct takes its own value.
+	if err := makeTree().RunArgsE([]string{"--rw-host", "rw-only", "--ro-host", "ro-only"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if rwHostMirror == roHostMirror {
+		t.Errorf("two preallocated substructs of the same pointer type share a single mirror: %p", rwHostMirror)
+	}
+	if finalRWHost != "rw-only" {
+		t.Errorf("finalRWHost = %q, want 'rw-only'", finalRWHost)
+	}
+	if finalROHost != "ro-only" {
+		t.Errorf("finalROHost = %q, want 'ro-only'", finalROHost)
+	}
+
+	// Cross-reject: RW's value rejected by RO's strict alts.
+	err := makeTree().RunArgsE([]string{"--rw-host", "rw-only", "--ro-host", "rw-only"})
+	if err == nil {
+		t.Errorf("RO should reject RW's alt value under strict alternatives")
+	}
+
+	// Cross-reject: RO's value rejected by RW's strict alts.
+	err = makeTree().RunArgsE([]string{"--rw-host", "ro-only", "--ro-host", "ro-only"})
+	if err == nil {
+		t.Errorf("RW should reject RO's alt value under strict alternatives")
+	}
+}

--- a/pkg/boa/param_meta.go
+++ b/pkg/boa/param_meta.go
@@ -37,6 +37,12 @@ type paramMeta struct {
 	flagPrefix string // kebab-case prefix for flag names
 	envPrefix  string // UPPER_SNAKE_CASE prefix for env var names
 
+	// pathKey is the fieldPath this param is stored under in the
+	// processingContext's mirrorByPath map. Stashed at creation so callers
+	// (e.g., the configfile tag handler) that have a *paramMeta can read its
+	// path directly instead of scanning pathOrder.
+	pathKey fieldPath
+
 	// Default value — stored as typed reflect.Value
 	defaultVal *reflect.Value
 

--- a/pkg/boa/subcommand_isolation_test.go
+++ b/pkg/boa/subcommand_isolation_test.go
@@ -1,0 +1,337 @@
+package boa
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// The tests in this file check that a single Params struct type can be used by a
+// root command and multiple subcommands, each applying its own set of programmatic
+// constraints via InitFuncCtx, without any cross-command interference.
+//
+// Each command has its own processingContext (built by its own toCobraBase call)
+// and therefore its own set of paramMeta instances keyed by fieldPath. Mirrors
+// are type-level identities instance-bound to a specific context — there is no
+// shared global mirror store. These tests make that invariant observable.
+
+// TestSubcommandIsolation_Alternatives — root, sub1, and sub2 share the same
+// Params type but each assigns a different strict alternatives set via
+// InitFuncCtx. Each command must accept its own alternatives and reject the
+// others.
+func TestSubcommandIsolation_Alternatives(t *testing.T) {
+	type Params struct {
+		Value string `descr:"value"`
+	}
+
+	// Captured per-invocation observations.
+	var rootRan, sub1Ran, sub2Ran bool
+	var rootVal, sub1Val, sub2Val string
+
+	// Factory: builds a fresh tree per invocation to avoid cobra flag-state
+	// leakage between Execute() calls.
+	makeTree := func() CmdT[Params] {
+		return CmdT[Params]{
+			Use: "root",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				ctx.GetParam(&p.Value).SetAlternatives([]string{"root-a", "root-b"})
+				return nil
+			},
+			RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+				rootRan = true
+				rootVal = p.Value
+			},
+			SubCmds: SubCmds(
+				CmdT[Params]{
+					Use: "sub1",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						ctx.GetParam(&p.Value).SetAlternatives([]string{"sub1-x", "sub1-y"})
+						return nil
+					},
+					RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+						sub1Ran = true
+						sub1Val = p.Value
+					},
+				},
+				CmdT[Params]{
+					Use: "sub2",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						ctx.GetParam(&p.Value).SetAlternatives([]string{"sub2-m", "sub2-n"})
+						return nil
+					},
+					RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+						sub2Ran = true
+						sub2Val = p.Value
+					},
+				},
+			),
+		}
+	}
+
+	reset := func() {
+		rootRan, sub1Ran, sub2Ran = false, false, false
+		rootVal, sub1Val, sub2Val = "", "", ""
+	}
+
+	// --- Each command accepts its own alternatives ---
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		wantRan *bool
+		wantVal string
+	}{
+		{"root accepts root-a", []string{"--value", "root-a"}, &rootRan, "root-a"},
+		{"sub1 accepts sub1-x", []string{"sub1", "--value", "sub1-x"}, &sub1Ran, "sub1-x"},
+		{"sub2 accepts sub2-m", []string{"sub2", "--value", "sub2-m"}, &sub2Ran, "sub2-m"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			if err := makeTree().RunArgsE(tc.args); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !*tc.wantRan {
+				t.Errorf("expected command to run")
+			}
+			switch tc.wantRan {
+			case &rootRan:
+				if rootVal != tc.wantVal {
+					t.Errorf("rootVal = %q, want %q", rootVal, tc.wantVal)
+				}
+			case &sub1Ran:
+				if sub1Val != tc.wantVal {
+					t.Errorf("sub1Val = %q, want %q", sub1Val, tc.wantVal)
+				}
+			case &sub2Ran:
+				if sub2Val != tc.wantVal {
+					t.Errorf("sub2Val = %q, want %q", sub2Val, tc.wantVal)
+				}
+			}
+		})
+	}
+
+	// --- Each command rejects values that belong to a sibling ---
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"root rejects sub1-x", []string{"--value", "sub1-x"}},
+		{"root rejects sub2-m", []string{"--value", "sub2-m"}},
+		{"sub1 rejects root-a", []string{"sub1", "--value", "root-a"}},
+		{"sub1 rejects sub2-m", []string{"sub1", "--value", "sub2-m"}},
+		{"sub2 rejects root-a", []string{"sub2", "--value", "root-a"}},
+		{"sub2 rejects sub1-x", []string{"sub2", "--value", "sub1-x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reset()
+			err := makeTree().RunArgsE(tc.args)
+			if err == nil {
+				t.Errorf("expected validation error, got nil")
+			}
+		})
+	}
+}
+
+// TestSubcommandIsolation_CustomValidators verifies that custom validators
+// registered on each command's mirror are called only for that command, never
+// leaking to siblings. This exercises the actual validation path (not just
+// alts matching) to confirm the per-command paramMeta instances are distinct.
+func TestSubcommandIsolation_CustomValidators(t *testing.T) {
+	type Params struct {
+		Value string `descr:"value"`
+	}
+
+	var rootCalls, sub1Calls, sub2Calls int
+
+	makeTree := func() CmdT[Params] {
+		return CmdT[Params]{
+			Use: "root",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				ctx.GetParam(&p.Value).SetCustomValidator(func(v any) error {
+					rootCalls++
+					if !strings.HasPrefix(v.(string), "root-") {
+						return fmt.Errorf("root expects prefix 'root-'")
+					}
+					return nil
+				})
+				return nil
+			},
+			RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+			SubCmds: SubCmds(
+				CmdT[Params]{
+					Use: "sub1",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						ctx.GetParam(&p.Value).SetCustomValidator(func(v any) error {
+							sub1Calls++
+							if !strings.HasPrefix(v.(string), "sub1-") {
+								return fmt.Errorf("sub1 expects prefix 'sub1-'")
+							}
+							return nil
+						})
+						return nil
+					},
+					RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+				},
+				CmdT[Params]{
+					Use: "sub2",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						ctx.GetParam(&p.Value).SetCustomValidator(func(v any) error {
+							sub2Calls++
+							if !strings.HasPrefix(v.(string), "sub2-") {
+								return fmt.Errorf("sub2 expects prefix 'sub2-'")
+							}
+							return nil
+						})
+						return nil
+					},
+					RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+				},
+			),
+		}
+	}
+
+	reset := func() { rootCalls, sub1Calls, sub2Calls = 0, 0, 0 }
+
+	// --- Invoke root: only root's validator runs ---
+	reset()
+	if err := makeTree().RunArgsE([]string{"--value", "root-ok"}); err != nil {
+		t.Fatalf("root exec: %v", err)
+	}
+	if rootCalls != 1 {
+		t.Errorf("rootCalls = %d, want 1", rootCalls)
+	}
+	if sub1Calls != 0 || sub2Calls != 0 {
+		t.Errorf("sub validators leaked into root: sub1=%d sub2=%d", sub1Calls, sub2Calls)
+	}
+
+	// --- Invoke sub1: only sub1's validator runs ---
+	reset()
+	if err := makeTree().RunArgsE([]string{"sub1", "--value", "sub1-ok"}); err != nil {
+		t.Fatalf("sub1 exec: %v", err)
+	}
+	if sub1Calls != 1 {
+		t.Errorf("sub1Calls = %d, want 1", sub1Calls)
+	}
+	if rootCalls != 0 || sub2Calls != 0 {
+		t.Errorf("validators leaked into sub1: root=%d sub2=%d", rootCalls, sub2Calls)
+	}
+
+	// --- Invoke sub2: only sub2's validator runs ---
+	reset()
+	if err := makeTree().RunArgsE([]string{"sub2", "--value", "sub2-ok"}); err != nil {
+		t.Fatalf("sub2 exec: %v", err)
+	}
+	if sub2Calls != 1 {
+		t.Errorf("sub2Calls = %d, want 1", sub2Calls)
+	}
+	if rootCalls != 0 || sub1Calls != 0 {
+		t.Errorf("validators leaked into sub2: root=%d sub1=%d", rootCalls, sub1Calls)
+	}
+
+	// --- Cross-command value rejection ---
+	reset()
+	if err := makeTree().RunArgsE([]string{"sub1", "--value", "root-x"}); err == nil {
+		t.Errorf("sub1 should reject 'root-x'")
+	}
+	// sub1's validator should have been called; root's should not have been.
+	if sub1Calls == 0 {
+		t.Errorf("sub1 validator was never invoked during rejection path")
+	}
+	if rootCalls != 0 {
+		t.Errorf("root validator leaked into sub1's validation: rootCalls=%d", rootCalls)
+	}
+}
+
+// TestSubcommandIsolation_MirrorIdentity spells out the underlying invariant:
+// each command in the tree owns a distinct mirror instance for the same
+// fieldPath, because each runs its own traverse inside its own processingContext.
+// The mirror a command configures in its InitFuncCtx must be the same instance
+// its RunFuncCtx sees — and it must NOT be the same instance as any sibling's
+// mirror for the same field.
+func TestSubcommandIsolation_MirrorIdentity(t *testing.T) {
+	type Params struct {
+		Value string `descr:"value"`
+	}
+
+	var rootInit, rootRun Param
+	var sub1Init, sub1Run Param
+	var sub2Init, sub2Run Param
+
+	makeTree := func() CmdT[Params] {
+		return CmdT[Params]{
+			Use: "root",
+			InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+				rootInit = ctx.GetParam(&p.Value)
+				return nil
+			},
+			RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+				rootRun = ctx.GetParam(&p.Value)
+			},
+			SubCmds: SubCmds(
+				CmdT[Params]{
+					Use: "sub1",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						sub1Init = ctx.GetParam(&p.Value)
+						return nil
+					},
+					RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+						sub1Run = ctx.GetParam(&p.Value)
+					},
+				},
+				CmdT[Params]{
+					Use: "sub2",
+					InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+						sub2Init = ctx.GetParam(&p.Value)
+						return nil
+					},
+					RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+						sub2Run = ctx.GetParam(&p.Value)
+					},
+				},
+			),
+		}
+	}
+
+	// Invoke each command in its own freshly built tree so none of them share
+	// any cobra state with another invocation.
+	if err := makeTree().RunArgsE([]string{"--value", "v"}); err != nil {
+		t.Fatalf("root: %v", err)
+	}
+	if rootInit == nil || rootRun == nil || rootInit != rootRun {
+		t.Errorf("root: init vs run mirror mismatch: init=%p run=%p", rootInit, rootRun)
+	}
+
+	if err := makeTree().RunArgsE([]string{"sub1", "--value", "v"}); err != nil {
+		t.Fatalf("sub1: %v", err)
+	}
+	if sub1Init == nil || sub1Run == nil || sub1Init != sub1Run {
+		t.Errorf("sub1: init vs run mirror mismatch: init=%p run=%p", sub1Init, sub1Run)
+	}
+
+	if err := makeTree().RunArgsE([]string{"sub2", "--value", "v"}); err != nil {
+		t.Fatalf("sub2: %v", err)
+	}
+	if sub2Init == nil || sub2Run == nil || sub2Init != sub2Run {
+		t.Errorf("sub2: init vs run mirror mismatch: init=%p run=%p", sub2Init, sub2Run)
+	}
+
+	// The mirrors from different commands must be distinct instances. Even
+	// though they describe the same field of the same type, they belong to
+	// different processingContexts built by different toCobraBase calls.
+	mirrors := []Param{rootInit, sub1Init, sub2Init}
+	seen := map[Param]string{}
+	names := []string{"root", "sub1", "sub2"}
+	for i, m := range mirrors {
+		if prior, dup := seen[m]; dup {
+			t.Errorf("mirror identity collision between commands %q and %q: both returned %p",
+				prior, names[i], m)
+		}
+		seen[m] = names[i]
+	}
+
+	// Quick sanity on deterministic path ordering in AllMirrors (just to make
+	// sure the new AllMirrors() is sensible — orthogonal to the main point).
+	_ = slices.Clone([]Param{rootInit})
+}

--- a/pkg/boa/substruct_reassignment_test.go
+++ b/pkg/boa/substruct_reassignment_test.go
@@ -1,8 +1,10 @@
 package boa
 
 import (
+	"reflect"
 	"slices"
 	"testing"
+	"unsafe"
 
 	"github.com/spf13/cobra"
 )
@@ -325,6 +327,83 @@ func TestReassignToNilAndBack(t *testing.T) {
 	}
 	if finalHost != "restored" {
 		t.Errorf("CLI value did not reach restored pointee: got %q", finalHost)
+	}
+}
+
+// TestGetParam_AutoRepairsCacheAfterReassignment verifies that when the
+// addrToPath cache is stale (because a substruct was reassigned after init),
+// the fallback walk in GetParam not only finds the mirror but also *repairs
+// the cache* so subsequent lookups for the same field address are O(1) again.
+//
+// This is a white-box test — it reaches into the internal addrToPath map to
+// verify the repair — because the optimization is not observable through the
+// public API except by microbenchmark. Verifying the map state is the direct
+// evidence that the repair code path ran.
+func TestGetParam_AutoRepairsCacheAfterReassignment(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host" default:"localhost"`
+	}
+	type Params struct {
+		DB *DB
+	}
+
+	var (
+		newHostAddr           unsafe.Pointer
+		cacheHadNewAddrBefore bool
+		cacheHadNewAddrAfter  bool
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			// Step 1: prime the cache with the preallocated pointee's addresses.
+			if m := ctx.GetParam(&params.DB.Host); m == nil {
+				t.Fatal("initial lookup returned nil")
+			}
+
+			// Step 2: reassign the substruct to a fresh pointee at a new heap
+			// address. Old cache entries are now stale; the new addresses have
+			// never been seen by addrToPath.
+			params.DB = &DB{Host: ""}
+			newHostAddr = reflect.ValueOf(&params.DB.Host).UnsafePointer()
+
+			// Check: the new address should NOT be in the cache yet.
+			if _, ok := ctx.ctx.addrToPath[newHostAddr]; ok {
+				cacheHadNewAddrBefore = true
+			}
+
+			// Step 3: do the lookup through the new address. The cache lookup
+			// will miss, the fallback walk will succeed, and (per the repair
+			// code) the new address should then be written into addrToPath.
+			m := ctx.GetParam(&params.DB.Host)
+			if m == nil {
+				t.Fatal("post-reassignment lookup returned nil")
+			}
+
+			// Check: after the lookup, the new address must now be in the cache.
+			if _, ok := ctx.ctx.addrToPath[newHostAddr]; ok {
+				cacheHadNewAddrAfter = true
+			}
+			return nil
+		},
+		RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{"--db-host", "x"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// Pre-condition: the new address was not cached before the fallback ran.
+	// (If this fires, the test setup is broken — we accidentally pre-populated
+	// the cache somehow.)
+	if cacheHadNewAddrBefore {
+		t.Errorf("precondition violated: new address was already cached before the fallback lookup")
+	}
+
+	// Post-condition: the fallback walk repaired the cache.
+	if !cacheHadNewAddrAfter {
+		t.Errorf("cache repair did not happen: new address is still not in addrToPath after fallback lookup")
 	}
 }
 

--- a/pkg/boa/substruct_reassignment_test.go
+++ b/pkg/boa/substruct_reassignment_test.go
@@ -1,0 +1,379 @@
+package boa
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestSubstructReassignmentPreservesMirror exercises the scenario the user asked
+// about directly:
+//
+//  1. An InitFuncCtx fetches the mirror for a field inside an optional substruct
+//     pointer (preallocated by boa) and configures it with a dynamic alternatives
+//     func.
+//  2. The user reassigns the entire substruct pointer — the new pointee has a
+//     different heap address, so `&params.DB.Host` now points into different memory.
+//  3. The hook fetches the mirror again via the new field address and applies a
+//     second, non-conflicting piece of configuration (a custom validator).
+//
+// The test verifies:
+//   - GetParam returns the SAME mirror instance after reassignment.
+//   - Both configurations (alternatives func + custom validator) are preserved on
+//     the final mirror.
+//   - CLI parsing still routes values into the (reassigned) substruct correctly.
+//
+// This is the load-bearing win of field-index keying: mirror state is owned by
+// the path, not by the original heap address of the substruct.
+func TestSubstructReassignmentPreservesMirror(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		DB *DB
+	}
+
+	var (
+		mirrorBeforeReassign Param
+		mirrorAfterReassign  Param
+		finalAltsFunc        func(cmd *cobra.Command, args []string, toComplete string) []string
+		finalValidator       func(any) error
+		finalHost            string
+		finalPort            int
+		validatorCalls       int
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			// Step 1: mirror via the preallocated pointee — set a dynamic alternatives func.
+			m1 := ctx.GetParam(&params.DB.Host)
+			if m1 == nil {
+				t.Fatal("mirror for DB.Host not found before reassignment")
+			}
+			m1.SetAlternativesFunc(func(cmd *cobra.Command, args []string, toComplete string) []string {
+				return []string{"gamma", "delta"}
+			})
+			mirrorBeforeReassign = m1
+
+			// Step 2: reassign the substruct pointer. The new pointee is at a different
+			// heap address, so &params.DB.Host now points into different memory.
+			params.DB = &DB{Host: "inline-default", Port: 9999}
+
+			// Step 3: mirror via the NEW field address — must resolve to the same instance.
+			m2 := ctx.GetParam(&params.DB.Host)
+			if m2 == nil {
+				t.Fatal("mirror for DB.Host not found after reassignment")
+			}
+			mirrorAfterReassign = m2
+
+			// Non-conflicting configuration: a custom validator.
+			m2.SetCustomValidator(func(v any) error {
+				validatorCalls++
+				return nil
+			})
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+			if p.DB != nil {
+				finalHost = p.DB.Host
+				finalPort = p.DB.Port
+			}
+			if m := ctx.GetParam(&p.DB.Host); m != nil {
+				finalAltsFunc = m.GetAlternativesFunc()
+				if pm, ok := m.(*paramMeta); ok {
+					finalValidator = pm.customValidator
+				}
+			}
+		},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{"--db-host", "alpha"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	// --- Mirror identity across reassignment ---
+	if mirrorBeforeReassign == nil || mirrorAfterReassign == nil {
+		t.Fatalf("mirror nil: before=%v after=%v", mirrorBeforeReassign, mirrorAfterReassign)
+	}
+	if mirrorBeforeReassign != mirrorAfterReassign {
+		t.Errorf("mirror identity changed across reassignment: before=%p after=%p",
+			mirrorBeforeReassign, mirrorAfterReassign)
+	}
+
+	// --- Configuration combined on final mirror ---
+	if finalAltsFunc == nil {
+		t.Errorf("alternatives func set BEFORE reassignment was lost")
+	} else {
+		got := finalAltsFunc(cmd, nil, "")
+		if !slices.Equal(got, []string{"gamma", "delta"}) {
+			t.Errorf("alternatives func returned wrong result: %v", got)
+		}
+	}
+	if finalValidator == nil {
+		t.Errorf("custom validator set AFTER reassignment was lost")
+	}
+	if validatorCalls == 0 {
+		t.Errorf("custom validator was never called during validation phase")
+	}
+
+	// --- CLI value reached the reassigned substruct ---
+	if finalHost != "alpha" {
+		t.Errorf("CLI value did not reach reassigned substruct: host=%q", finalHost)
+	}
+	// Port was set by reassignment (not CLI). If syncMirrors injected the non-zero
+	// raw value, cleanupPreallocatedPtrs should see the struct as "set" and leave
+	// it alive. Document the observed behavior rather than assume.
+	if finalPort != 9999 {
+		t.Logf("reassignment-set port value did not survive: port=%d (may be expected; see cleanupPreallocatedPtrs)", finalPort)
+	}
+}
+
+// TestDeepNestedReassignment_FullTree exercises the full-tree-reassignment case
+// for deeply nested pointer substructs: the user replaces the outermost pointer,
+// which transitively replaces every inner pointer and leaf. Every intermediate
+// heap address changes. GetParam must still resolve mirror identity through the
+// new tree.
+func TestDeepNestedReassignment_FullTree(t *testing.T) {
+	type Leaf struct {
+		Value string `descr:"value"`
+	}
+	type Middle struct {
+		Leaf *Leaf
+	}
+	type Outer struct {
+		Middle *Middle
+	}
+	type Params struct {
+		Outer *Outer
+	}
+
+	var (
+		mBefore    Param
+		mAfter     Param
+		finalValue string
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			mBefore = ctx.GetParam(&params.Outer.Middle.Leaf.Value)
+			if mBefore == nil {
+				t.Fatal("mirror for Outer.Middle.Leaf.Value not found before reassignment")
+			}
+			mBefore.SetDefault(Default("initial-default"))
+
+			// Replace the entire tree — every heap address below params.Outer changes.
+			params.Outer = &Outer{Middle: &Middle{Leaf: &Leaf{Value: ""}}}
+
+			mAfter = ctx.GetParam(&params.Outer.Middle.Leaf.Value)
+			if mAfter == nil {
+				t.Fatal("mirror for Outer.Middle.Leaf.Value not found after reassignment")
+			}
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+			if p.Outer != nil && p.Outer.Middle != nil && p.Outer.Middle.Leaf != nil {
+				finalValue = p.Outer.Middle.Leaf.Value
+			}
+		},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{"--outer-middle-leaf-value", "cli-supplied"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if mBefore != mAfter {
+		t.Errorf("mirror identity changed across full-tree reassignment: before=%p after=%p", mBefore, mAfter)
+	}
+	if finalValue != "cli-supplied" {
+		t.Errorf("CLI value did not reach the deeply nested reassigned field: got %q", finalValue)
+	}
+}
+
+// TestDeepNestedReassignment_MiddleOnly exercises the partial-reassignment case:
+// only the middle pointer is replaced, leaving the outer pointer identity intact.
+// Path resolution must walk through the unchanged outer and the new middle.
+func TestDeepNestedReassignment_MiddleOnly(t *testing.T) {
+	type Leaf struct {
+		Value string `descr:"value"`
+	}
+	type Middle struct {
+		Leaf *Leaf
+	}
+	type Outer struct {
+		Middle *Middle
+	}
+	type Params struct {
+		Outer *Outer
+	}
+
+	var (
+		mBefore    Param
+		mAfter     Param
+		finalValue string
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			mBefore = ctx.GetParam(&params.Outer.Middle.Leaf.Value)
+			if mBefore == nil {
+				t.Fatal("mirror not found before middle reassignment")
+			}
+
+			// Replace only Middle (Outer stays the same preallocated instance).
+			params.Outer.Middle = &Middle{Leaf: &Leaf{Value: ""}}
+
+			mAfter = ctx.GetParam(&params.Outer.Middle.Leaf.Value)
+			if mAfter == nil {
+				t.Fatal("mirror not found after middle reassignment")
+			}
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+			if p.Outer != nil && p.Outer.Middle != nil && p.Outer.Middle.Leaf != nil {
+				finalValue = p.Outer.Middle.Leaf.Value
+			}
+		},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{"--outer-middle-leaf-value", "partial"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if mBefore != mAfter {
+		t.Errorf("mirror identity changed across middle reassignment: before=%p after=%p", mBefore, mAfter)
+	}
+	if finalValue != "partial" {
+		t.Errorf("CLI value did not reach reassigned middle: got %q", finalValue)
+	}
+}
+
+// TestReassignToNilAndBack exercises the case where a user clears a substruct
+// pointer (sets it to nil) and then sets it back to a fresh non-nil pointee.
+// GetParam must return nil while the pointer is nil, then resolve the mirror
+// again once the pointer is restored.
+func TestReassignToNilAndBack(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host"`
+	}
+	type Params struct {
+		DB *DB
+	}
+
+	var (
+		mBefore   Param
+		mDuringNil Param
+		mAfter    Param
+		finalHost string
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			mBefore = ctx.GetParam(&params.DB.Host)
+			if mBefore == nil {
+				t.Fatal("mirror not found initially")
+			}
+
+			// Nil the substruct — while nil, the path cannot be resolved.
+			params.DB = nil
+			// We cannot call &params.DB.Host here (it would segfault); probe via the
+			// authoritative store instead using a known path.
+			if ctx != nil && ctx.ctx != nil {
+				if m, ok := ctx.ctx.mirrorByPath["0.0"]; ok {
+					mDuringNil = m // mirror still present in authoritative store
+				}
+			}
+
+			// Restore to a fresh pointee at a new heap address.
+			params.DB = &DB{Host: ""}
+			mAfter = ctx.GetParam(&params.DB.Host)
+			if mAfter == nil {
+				t.Fatal("mirror not found after restoration")
+			}
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+			if p.DB != nil {
+				finalHost = p.DB.Host
+			}
+		},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{"--db-host", "restored"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if mBefore != mAfter {
+		t.Errorf("mirror identity changed across nil-and-back: before=%p after=%p", mBefore, mAfter)
+	}
+	if mDuringNil != mBefore {
+		t.Errorf("mirror dropped from authoritative store while pointer was nil: during=%p before=%p", mDuringNil, mBefore)
+	}
+	if finalHost != "restored" {
+		t.Errorf("CLI value did not reach restored pointee: got %q", finalHost)
+	}
+}
+
+// TestEmbeddedPointerStructReassignment covers anonymous (embedded) pointer
+// struct fields, which get no flag-name prefix per boa's promotion rules. After
+// reassigning the embedded pointer, the mirror for a promoted field must still
+// be reachable via `&outer.Promoted`.
+func TestEmbeddedPointerStructReassignment(t *testing.T) {
+	type Inner struct {
+		Thing string `descr:"thing"`
+	}
+	type Params struct {
+		*Inner
+	}
+
+	var (
+		mBefore    Param
+		mAfter     Param
+		finalThing string
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			mBefore = ctx.GetParam(&params.Thing)
+			if mBefore == nil {
+				t.Fatal("mirror for embedded field not found before reassignment")
+			}
+
+			params.Inner = &Inner{Thing: ""}
+
+			mAfter = ctx.GetParam(&params.Thing)
+			if mAfter == nil {
+				t.Fatal("mirror for embedded field not found after reassignment")
+			}
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command, args []string) {
+			if p.Inner != nil {
+				finalThing = p.Thing
+			}
+		},
+	}).ToCobra()
+
+	// Embedded → no prefix, so the flag is just --thing.
+	cmd.SetArgs([]string{"--thing", "embedded-value"})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if mBefore != mAfter {
+		t.Errorf("mirror identity changed across embedded reassignment: before=%p after=%p", mBefore, mAfter)
+	}
+	if finalThing != "embedded-value" {
+		t.Errorf("CLI value did not reach reassigned embedded struct: got %q", finalThing)
+	}
+}

--- a/pkg/boa/substruct_reassignment_test.go
+++ b/pkg/boa/substruct_reassignment_test.go
@@ -335,10 +335,16 @@ func TestReassignToNilAndBack(t *testing.T) {
 // the fallback walk in GetParam not only finds the mirror but also *repairs
 // the cache* so subsequent lookups for the same field address are O(1) again.
 //
-// This is a white-box test — it reaches into the internal addrToPath map to
-// verify the repair — because the optimization is not observable through the
-// public API except by microbenchmark. Verifying the map state is the direct
-// evidence that the repair code path ran.
+// The test makes four independent observations:
+//
+//  1. Pre-condition: the new address is not in addrToPath before the lookup.
+//  2. Exactly one fallback walk runs for the post-reassignment lookup.
+//  3. Post-condition: the new address IS in addrToPath after the lookup.
+//  4. A second lookup through the same new address does NOT trigger another
+//     fallback walk — the repair made it O(1) again.
+//
+// This is a white-box test: it reaches into processingContext internals
+// because the optimization is invisible through the public API.
 func TestGetParam_AutoRepairsCacheAfterReassignment(t *testing.T) {
 	type DB struct {
 		Host string `descr:"host" default:"localhost"`
@@ -351,6 +357,10 @@ func TestGetParam_AutoRepairsCacheAfterReassignment(t *testing.T) {
 		newHostAddr           unsafe.Pointer
 		cacheHadNewAddrBefore bool
 		cacheHadNewAddrAfter  bool
+		walksAfterFirstLookup int
+		walksAfterSecondLookup int
+		rebuildsAfterFirst    int
+		rebuildsAfterSecond   int
 	)
 
 	cmd := (CmdT[Params]{
@@ -371,19 +381,32 @@ func TestGetParam_AutoRepairsCacheAfterReassignment(t *testing.T) {
 			if _, ok := ctx.ctx.addrToPath[newHostAddr]; ok {
 				cacheHadNewAddrBefore = true
 			}
+			walksBefore := ctx.ctx.walkFallbackCount
+			rebuildsBefore := ctx.ctx.cacheRebuildCount
 
-			// Step 3: do the lookup through the new address. The cache lookup
-			// will miss, the fallback walk will succeed, and (per the repair
-			// code) the new address should then be written into addrToPath.
-			m := ctx.GetParam(&params.DB.Host)
-			if m == nil {
+			// Step 3: first lookup through the new address. Expect the fallback
+			// walk to fire exactly once and repair the cache.
+			if m := ctx.GetParam(&params.DB.Host); m == nil {
 				t.Fatal("post-reassignment lookup returned nil")
 			}
+			walksAfterFirstLookup = ctx.ctx.walkFallbackCount - walksBefore
+			rebuildsAfterFirst = ctx.ctx.cacheRebuildCount - rebuildsBefore
 
 			// Check: after the lookup, the new address must now be in the cache.
 			if _, ok := ctx.ctx.addrToPath[newHostAddr]; ok {
 				cacheHadNewAddrAfter = true
 			}
+
+			// Step 4: second lookup through the same new address. The cache
+			// repair from step 3 should make this an O(1) cache hit — no walk,
+			// no rebuild, no further state change.
+			walksMid := ctx.ctx.walkFallbackCount
+			rebuildsMid := ctx.ctx.cacheRebuildCount
+			if m := ctx.GetParam(&params.DB.Host); m == nil {
+				t.Fatal("second post-reassignment lookup returned nil")
+			}
+			walksAfterSecondLookup = ctx.ctx.walkFallbackCount - walksMid
+			rebuildsAfterSecond = ctx.ctx.cacheRebuildCount - rebuildsMid
 			return nil
 		},
 		RunFunc: func(p *Params, c *cobra.Command, args []string) {},
@@ -395,15 +418,97 @@ func TestGetParam_AutoRepairsCacheAfterReassignment(t *testing.T) {
 	}
 
 	// Pre-condition: the new address was not cached before the fallback ran.
-	// (If this fires, the test setup is broken — we accidentally pre-populated
-	// the cache somehow.)
 	if cacheHadNewAddrBefore {
 		t.Errorf("precondition violated: new address was already cached before the fallback lookup")
+	}
+
+	// The first post-reassignment lookup should fire exactly one fallback walk.
+	if walksAfterFirstLookup != 1 {
+		t.Errorf("first post-reassignment lookup: expected 1 fallback walk, got %d", walksAfterFirstLookup)
+	}
+	// And no cache rebuild (rebuilds are only triggered when addrToPath is nil;
+	// here it's just stale, not nil).
+	if rebuildsAfterFirst != 0 {
+		t.Errorf("first post-reassignment lookup: expected 0 cache rebuilds, got %d", rebuildsAfterFirst)
 	}
 
 	// Post-condition: the fallback walk repaired the cache.
 	if !cacheHadNewAddrAfter {
 		t.Errorf("cache repair did not happen: new address is still not in addrToPath after fallback lookup")
+	}
+
+	// The second lookup for the same address must hit the cache — no walk, no rebuild.
+	if walksAfterSecondLookup != 0 {
+		t.Errorf("second post-reassignment lookup walked the tree again: got %d walks, want 0 (cache repair did not take effect)", walksAfterSecondLookup)
+	}
+	if rebuildsAfterSecond != 0 {
+		t.Errorf("second post-reassignment lookup triggered a cache rebuild: got %d, want 0", rebuildsAfterSecond)
+	}
+}
+
+// TestGetParam_HappyPathNoWalkNoRebuild verifies that in ordinary usage (no
+// substruct reassignment, no subtree removal), GetParam never triggers the
+// fallback walk or a cache rebuild — it always hits the cache that was
+// populated incrementally during traverse.
+//
+// This pins the performance expectation: users calling ctx.GetParam(&p.X)
+// from InitFuncCtx, PostCreateFuncCtx, PreValidateFuncCtx, or RunFuncCtx on
+// a stable parameters tree pay zero walk / zero rebuild cost per call.
+func TestGetParam_HappyPathNoWalkNoRebuild(t *testing.T) {
+	type DB struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		Name string `descr:"name" default:"default"`
+		DB   DB
+	}
+
+	var (
+		walksAtEnd    int
+		rebuildsAtEnd int
+	)
+
+	cmd := (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, p *Params, c *cobra.Command) error {
+			// Record baseline AFTER traverse has populated the cache, so we're
+			// only measuring GetParam call costs, not traverse overhead.
+			walksBefore := ctx.ctx.walkFallbackCount
+			rebuildsBefore := ctx.ctx.cacheRebuildCount
+
+			// Exercise a handful of lookups across the struct — root field and
+			// nested substruct fields. Every one should be a cache hit because
+			// nothing has invalidated addrToPath.
+			for i := 0; i < 5; i++ {
+				if m := ctx.GetParam(&p.Name); m == nil {
+					t.Fatalf("lookup %d: p.Name returned nil", i)
+				}
+				if m := ctx.GetParam(&p.DB.Host); m == nil {
+					t.Fatalf("lookup %d: p.DB.Host returned nil", i)
+				}
+				if m := ctx.GetParam(&p.DB.Port); m == nil {
+					t.Fatalf("lookup %d: p.DB.Port returned nil", i)
+				}
+			}
+
+			walksAtEnd = ctx.ctx.walkFallbackCount - walksBefore
+			rebuildsAtEnd = ctx.ctx.cacheRebuildCount - rebuildsBefore
+			return nil
+		},
+		RunFunc: func(p *Params, c *cobra.Command, args []string) {},
+	}).ToCobra()
+
+	cmd.SetArgs([]string{})
+	if err := Execute(cmd); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if walksAtEnd != 0 {
+		t.Errorf("happy-path lookups walked the tree %d times, want 0 (cache was missed unexpectedly)", walksAtEnd)
+	}
+	if rebuildsAtEnd != 0 {
+		t.Errorf("happy-path lookups rebuilt the cache %d times, want 0 (cache was invalidated unexpectedly)", rebuildsAtEnd)
 	}
 }
 

--- a/pkg/boa/substruct_reassignment_test.go
+++ b/pkg/boa/substruct_reassignment_test.go
@@ -284,11 +284,16 @@ func TestReassignToNilAndBack(t *testing.T) {
 
 			// Nil the substruct — while nil, the path cannot be resolved.
 			params.DB = nil
-			// We cannot call &params.DB.Host here (it would segfault); probe via the
-			// authoritative store instead using a known path.
+			// We cannot call &params.DB.Host here (it would segfault on the nil
+			// dereference), so we intentionally reach into the internal mirrorByPath
+			// to verify the invariant this test exists to prove: the mirror stays in
+			// the authoritative store even while the pointer that used to address it
+			// is nil. This is a deliberate test-only coupling to internal state —
+			// the mirror store is the single source of truth, and field-address
+			// resolution is just a convenience layered on top.
 			if ctx != nil && ctx.ctx != nil {
 				if m, ok := ctx.ctx.mirrorByPath["0.0"]; ok {
-					mDuringNil = m // mirror still present in authoritative store
+					mDuringNil = m
 				}
 			}
 


### PR DESCRIPTION
## Background

Today, boa's parameter mirrors are stored in `processingContext.RawAddrToMirror`, a `map[unsafe.Pointer]Param` keyed by `fieldAddr.UnsafePointer()` — the raw memory address of each field slot in the user's params struct. The address map is the **authoritative** store: every lookup, dedup, subtree walk, removal, and sync path computes a `unsafe.Pointer` from a reflect value and uses it as the key.

This works (Go pins struct memory, addresses are stable for the lifetime of the value), but the authoritative identity of every mirror is implicitly \"the field at address X of the struct instance that was live when traverse ran.\" Three latent consequences:

1. **Fragile under pointer-substruct reassignment.** If a user's `InitFunc` does `params.DB = &DBConfig{...}`, every mirror for `DB.*` is silently orphaned — the map still contains entries, but they point at GC'd memory. Today's code dodges this by preallocating before init hooks and trusting users not to reassign. Nothing catches a violation — you get a mysterious \"mirror not found\" or a confusing nil-dereference at the caller's chained `.SetX(...)` line, far from the real bug.
2. **Opaque in logs.** Mirror-lookup diagnostics show `0xc0000a8040` instead of `db.host`, which makes any failure in the lookup machinery hard to trace.
3. **Subtree operations are O(n_mirrors × depth) recursive reflect walks** rather than O(n_subtree_mirrors) prefix queries — because the key doesn't carry hierarchical structure.

## What this PR does: move the mirror identity from instance-memory to type-path

Introduces `fieldPath` — a string-serialized `[]int` declared-index path rooted at the params struct (e.g., `0.2.1` = field 0 → its field 2 → its field 1) — and makes it the authoritative mirror key.

- `mirrorByPath map[fieldPath]Param` — authoritative store. The identity of a mirror is its position in the struct type, not its memory address. Two `processingContext`s built over the same struct type will have entries at identical keys.
- `pathOrder []fieldPath` — preserves traverse-insertion order for deterministic sync iteration.
- `addrToPath map[unsafe.Pointer]fieldPath` — **non-authoritative** reverse-index cache. Its sole job is to support `HookContext.GetParam(&params.Field)`, the ergonomic API where users hand us a raw Go field pointer. It can be invalidated and rebuilt from `mirrorByPath` + the root struct without losing any mirror state.

The `traverse` function now threads a `path []int` alongside the existing prefix string, always using the **declared field index** (loop variable `i`), never a visit counter — so interleaved `boa:\"ignore\"` fields cannot drift subsequent siblings.

Subtree operations (`removeMirrorsForSubtree`, `markAllMirrorsInSubtree`, `collectAndCheck`, `markConfigKeysPresentInStruct`) take a `[]int` prefix. Removal becomes a ~10-line string-prefix purge on the map instead of a recursive reflect walk.

`syncMirrors` iterates `pathOrder`, resolves each leaf via `FieldByIndex`-style walking from the root (with nil-pointer safety), and uses a new `reinterpretAs` helper to view type-aliased fields (e.g., a `MyString` field seen as `string`) through their underlying type.

`HookContext` is now a thin wrapper around `processingContext`. `GetParam(&field)` looks up `addrToPath`; on a miss it rebuilds the cache; on a second miss (e.g., after the user reassigned a substruct) it falls back to walking the live tree from the root. On a successful fallback hit, the cache is repaired opportunistically so subsequent lookups are O(1) again. `AllMirrors()` iterates `pathOrder` for deterministic order.

**Public API is unchanged.** Every caller of `HookContext.GetParam`, `AllMirrors`, `Param` methods, `InitFuncCtx`/`PreValidateFuncCtx`/etc. compiles and runs unchanged.

### On unsafe.Pointer

Earlier drafts of this description oversold \"demote `unsafe`.\" An honest accounting: `unsafe.Pointer` is still in the reverse-index cache, and `reinterpretAs` in `syncMirrors` still does a memory reinterpret for type-aliased fields. The grep count is approximately unchanged.

**The real win is identity stability, not `unsafe` elimination.** The authoritative mirror store is now keyed by something that survives pointer-substruct reassignment, makes subtree operations honest prefix queries, and produces human-readable diagnostics. `unsafe.Pointer` survives in two clearly-bounded roles: a rebuildable ergonomic cache, and a single memory reinterpret in the sync path that was already in the old code.

## Behavior change: `GetParam` emits `slog.Error` on invalid lookups

`GetParam` previously returned `nil` silently for foreign-field lookups, typed nils, and non-pointer inputs. It now emits a descriptive `slog.Error` log line for each such case while still returning `nil` (preserving the prior \"probe without crashing\" contract that `TestGetParam_ReturnsNilForUnknownField` documents). This is a semi-observable behavior change: programs that parse boa's log output may see new lines; programs that don't won't notice. Worth mentioning in release notes.

## Why we might want this

### Pros

- **Reassignment-safe.** The scenario that silently breaks today now works: a user fetches a mirror, configures it, reassigns the substruct pointer, fetches the mirror again through the new address, applies more configuration, and both pieces survive. See `TestSubstructReassignmentPreservesMirror` and friends.
- **Subtree ops become trivial.** `removeMirrorsForSubtree` is 10 lines of `strings.HasPrefix` instead of a recursive reflect walk.
- **Paths are human-readable.** Debug logs can show `0.2.1` instead of hex addresses. Tests can assert on paths directly.
- **`addrToPath` is demotable.** Lose it, rebuild it, mirror state is untouched.
- **Native handling of embedded fields.** Go's `reflect` represents promoted fields (named-pointer and anonymous) as multi-element `StructField.Index` paths. The authoritative key is now in the same language `reflect` speaks natively.
- **Foundational for `boa.Validate[T](&p)`**: the refactor moves the type-vs-instance boundary from inside each mirror to the context, which is the decoupling needed for a future non-CLI validation entry point. Out of scope for this PR; noted for a later one.

### Cons / honest accounting

- **`unsafe.Pointer` is not eliminated**, it is demoted to a rebuildable cache plus one memory reinterpret in sync. If you grep for `unsafe.Pointer`, you still find it.
- **Slightly more code.** Two maps instead of one; helpers for path join/split, resolve-field-value, rebuild-addr-cache, walking fallback, reinterpret-as. Roughly +600 net lines across the core files.
- **No user-visible feature change.** This is a quality refactor, not a feature. Every gain is internal: maintainability, debuggability, robustness to edge cases.
- **Slightly more work at mirror lookup.** `FieldByIndex`-style resolution is O(depth) instead of O(1). Paths are 1–3 deep in practice and this is init-time code.
- **`GetParam` is noisier by default.** See the behavior-change section above.

## Tests added

### Reassignment (`substruct_reassignment_test.go`)
Five scenarios that would silently break the current address-keyed design:

1. `TestSubstructReassignmentPreservesMirror` — baseline.
2. `TestDeepNestedReassignment_FullTree` — Outer→Middle→Leaf all replaced.
3. `TestDeepNestedReassignment_MiddleOnly` — only the middle pointer replaced.
4. `TestReassignToNilAndBack` — mirror survives the authoritative store while the pointer is nil.
5. `TestEmbeddedPointerStructReassignment` — anonymous `*Inner` with promoted fields.

### Subcommand isolation (`subcommand_isolation_test.go`)
Three tests proving each command in a `root { sub1, sub2 }` tree has its own `processingContext` and its own mirrors even when every command uses the same `Params` type. Alternatives, custom validators, and mirror identity are all independent.

### Multi-substruct of same type (`multi_substruct_test.go`)
Two tests for `type Params struct { RW DB; RO DB }` (and its `*DB` pointer variant) — independent mirrors, independent alternatives, independent custom validators, CLI values routed correctly.

### Foreign-field logging (`foreign_field_lookup_test.go`)
Five tests capturing `slog` output to verify that foreign field, different-instance-same-type, nil fieldPtr, and non-pointer fieldPtr each produce a descriptive log line naming the cause, while still returning `nil` to preserve the existing contract.

All existing tests — `pkg/boa`, `pkg/boaviper`, every `internal/testmain*` integration — pass unchanged.

## Status

Draft. Looking for feedback on the design tradeoffs in the \"Cons\" section, and any scenarios not covered by the test files above that should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging when retrieving parameters from invalid or unrelated struct pointers.
  * Enhanced stability of parameter references when pointer substructs are reassigned after initialization.
  * Fixed parameter isolation across subcommands sharing the same parameter type.
  * Corrected handling of multiple similar sub-struct fields to prevent cross-contamination.

* **Tests**
  * Added test coverage for pointer substruct reassignment scenarios.
  * Added subcommand parameter isolation verification tests.
  * Added parameter lookup error reporting tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->