### PR TITLE
feat: pluggable config file formats with key-tree probing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,14 @@ type Params struct {
 - `boa:"configonly"` - Alias for `boa:"ignore"` (clearer intent for config-file-only fields)
 
 ### Config Format Registry
-- `boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)` registers custom config formats by file extension
-- JSON is the only format shipped by default
-- `boa.ConfigFormatExtensions()` returns all registered file extensions (used by `boaviper`)
-- Resolution: explicit `Cmd.ConfigUnmarshal` > file extension registry > `json.Unmarshal` fallback
+- `boa.ConfigFormat{Unmarshal, KeyTree}` describes a full format: an unmarshaler plus an optional `KeyTree func([]byte) (map[string]any, error)` used for set-by-config detection.
+- `boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)` is a shortcut for a format with only `Unmarshal`; falls back to snapshot comparison for detection.
+- `boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{...})` registers the full form — required to detect zero-value or same-as-default writes to optional struct-pointer groups.
+- JSON is the only format shipped by default (built-in `KeyTree` backed by `json.Unmarshal`).
+- `boa.ConfigFormatExtensions()` returns all registered file extensions (used by `boaviper`).
+- Per-command overrides: `Cmd.ConfigFormat` (full form, preferred) and `Cmd.ConfigUnmarshal` (legacy, unmarshal-only). `ConfigFormat` wins when both are set.
+- Resolution: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > extension-registered format > JSON fallback.
+- `KeyTree` may return nested values as `map[string]any` (native) or `map[any]any` (e.g. yaml.v2); boa coerces transparently via `asKeyMap`.
 - Substruct `configfile:"true"` fields load their own config files; priority: CLI > env > root config > substruct config > defaults
 
 ### Custom Type Registration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,9 @@ type Params struct {
 ### Config Format Registry
 - Dispatch is **extension-driven**: every `loadConfigFileInto` call resolves the format from `filepath.Ext(filePath)` against the global `configFormats` map, so one binary can load any mix of registered formats at runtime.
 - `boa.ConfigFormat{Unmarshal, KeyTree}` describes a full format: an unmarshaler plus an optional `KeyTree func([]byte) (map[string]any, error)` used for set-by-config detection.
-- `boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)` is a shortcut for a format with only `Unmarshal`; falls back to snapshot comparison for detection.
-- `boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{...})` registers the full form — required to detect zero-value or same-as-default writes to optional struct-pointer groups.
+- `boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)` is the one-liner for every mainstream Go parser. It wraps the unmarshaler in a `UniversalConfigFormat`, which synthesizes `KeyTree` by decoding the same bytes into `map[string]any`. Full key-presence detection is automatic; panics on nil.
+- `boa.UniversalConfigFormat(unmarshalFunc)` is the exported helper for inline use with `Cmd.ConfigFormat`. Panics on nil.
+- `boa.RegisterConfigFormatFull(".mycustom", boa.ConfigFormat{...})` is the advanced form — reach for it only when the parser cannot decode into `map[string]any` (e.g., a handwritten format that only populates specific struct types), in which case you supply a hand-written `KeyTree`.
 - JSON is the only format shipped by default (built-in `KeyTree` backed by `json.Unmarshal`).
 - `boa.ConfigFormatExtensions()` returns all registered file extensions (used by `boaviper`).
 - `Cmd.ConfigFormat` / legacy `Cmd.ConfigUnmarshal` are **per-command escape hatches** that lock that one command to a single format, bypassing the extension registry. Prefer registry-based dispatch unless you have a specific reason (legacy blob ingestion, test fixtures).
@@ -142,7 +143,7 @@ CLI args > Environment vars > Root config file > Substruct config files > Defaul
 - `p.DB == nil` means nothing in the group was configured; `p.DB != nil` means at least one field was set
 - Defaults alone don't keep the struct alive — only explicit user input does
 - Nested pointer structs work: `Outer *OuterConfig` where OuterConfig has `Inner *InnerConfig`
-- Config file key-presence detection handles zero-value and same-as-default config entries for any format whose `ConfigFormat` supplies a `KeyTree` probe (JSON is built in; YAML/TOML/… opt in by registering their own `KeyTree`)
+- Config file key-presence detection handles zero-value and same-as-default config entries for any format whose `ConfigFormat` supplies a `KeyTree` probe. `RegisterConfigFormat(ext, fn)` auto-synthesizes one via `UniversalConfigFormat`, so YAML/TOML/HCL get it for free; only formats whose unmarshaler cannot decode into `map[string]any` need to supply their own.
 - Works with all features: validation tags, custom validators, alternatives, HookContext access
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,13 +75,14 @@ type Params struct {
 - `boa:"configonly"` - Alias for `boa:"ignore"` (clearer intent for config-file-only fields)
 
 ### Config Format Registry
+- Dispatch is **extension-driven**: every `loadConfigFileInto` call resolves the format from `filepath.Ext(filePath)` against the global `configFormats` map, so one binary can load any mix of registered formats at runtime.
 - `boa.ConfigFormat{Unmarshal, KeyTree}` describes a full format: an unmarshaler plus an optional `KeyTree func([]byte) (map[string]any, error)` used for set-by-config detection.
 - `boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)` is a shortcut for a format with only `Unmarshal`; falls back to snapshot comparison for detection.
 - `boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{...})` registers the full form — required to detect zero-value or same-as-default writes to optional struct-pointer groups.
 - JSON is the only format shipped by default (built-in `KeyTree` backed by `json.Unmarshal`).
 - `boa.ConfigFormatExtensions()` returns all registered file extensions (used by `boaviper`).
-- Per-command overrides: `Cmd.ConfigFormat` (full form, preferred) and `Cmd.ConfigUnmarshal` (legacy, unmarshal-only). `ConfigFormat` wins when both are set.
-- Resolution: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > extension-registered format > JSON fallback.
+- `Cmd.ConfigFormat` / legacy `Cmd.ConfigUnmarshal` are **per-command escape hatches** that lock that one command to a single format, bypassing the extension registry. Prefer registry-based dispatch unless you have a specific reason (legacy blob ingestion, test fixtures).
+- Resolution per load: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > extension-registered format > JSON fallback.
 - `KeyTree` may return nested values as `map[string]any` (native) or `map[any]any` (e.g. yaml.v2); boa coerces transparently via `asKeyMap`.
 - Substruct `configfile:"true"` fields load their own config files; priority: CLI > env > root config > substruct config > defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ type Params struct {
 
 ### Boaviper Subpackage (`pkg/boaviper/`)
 - `boaviper.AutoConfig[T]("appname")` - InitFunc for auto-discovering config files in standard paths
-- `boaviper.FindConfig("appname")` - Searches standard paths (`./<app>.json`, `~/.config/<app>/config.json`, `/etc/<app>/config.json`)
+- `boaviper.FindConfig("appname")` - Searches standard paths (`./<app>`, `~/.config/<app>/config`, `/etc/<app>/config`) trying every extension returned by `boa.ConfigFormatExtensions()` (so `.json` plus anything registered via `RegisterConfigFormat` / `RegisterConfigFormatFull`)
 - `boaviper.SetEnvPrefix("PREFIX")` - Enricher that combines `ParamEnricherEnv` + `ParamEnricherEnvPrefix`
 - Uses `boa.ConfigFormatExtensions()` to try all registered formats
 
@@ -142,7 +142,7 @@ CLI args > Environment vars > Root config file > Substruct config files > Defaul
 - `p.DB == nil` means nothing in the group was configured; `p.DB != nil` means at least one field was set
 - Defaults alone don't keep the struct alive — only explicit user input does
 - Nested pointer structs work: `Outer *OuterConfig` where OuterConfig has `Inner *InnerConfig`
-- Config file key-presence detection handles zero-value and same-as-default config entries (JSON only)
+- Config file key-presence detection handles zero-value and same-as-default config entries for any format whose `ConfigFormat` supplies a `KeyTree` probe (JSON is built in; YAML/TOML/… opt in by registering their own `KeyTree`)
 - Works with all features: validation tags, custom validators, alternatives, HookContext access
 
 ## Testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,9 @@ type Params struct {
 - `boa.UniversalConfigFormat(unmarshalFunc)` is the exported helper for inline use with `Cmd.ConfigFormat`. Panics on nil.
 - `boa.RegisterConfigFormatFull(".mycustom", boa.ConfigFormat{...})` is the advanced form — reach for it only when the parser cannot decode into `map[string]any` (e.g., a handwritten format that only populates specific struct types), in which case you supply a hand-written `KeyTree`.
 - JSON is the only format shipped by default (built-in `KeyTree` backed by `json.Unmarshal`).
-- `boa.ConfigFormatExtensions()` returns all registered file extensions (used by `boaviper`).
+- Registry access is guarded by a `sync.RWMutex`; registration is goroutine-safe. Still, the normal pattern is to register from `init()` / startup for clarity.
+- `boa.ConfigFormatExtensions()` returns all registered file extensions, **sorted alphabetically** for deterministic iteration (important for `boaviper.FindConfig` which probes the same search path with every registered extension).
+- Snapshot fallback for formats without a usable `KeyTree` is scoped per-load — a failing sub-load only triggers fallback within its own subtree, so it cannot corrupt the precision of sibling loads whose KeyTree succeeded.
 - `Cmd.ConfigFormat` / legacy `Cmd.ConfigUnmarshal` are **per-command escape hatches** that lock that one command to a single format, bypassing the extension registry. Prefer registry-based dispatch unless you have a specific reason (legacy blob ingestion, test fixtures).
 - Resolution per load: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > extension-registered format > JSON fallback.
 - `KeyTree` may return nested values as `map[string]any` (native) or `map[any]any` (e.g. yaml.v2); boa coerces transparently via `asKeyMap`.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -182,7 +182,9 @@ CLI and env var values always take precedence over config file values.
 
 ### Config Format Registry
 
-JSON is the only format shipped by default. Register additional formats by file extension:
+JSON is the only format shipped by default. BOA has no third-party parser dependencies — you bring your own library and register it in the global registry. The registry is keyed by file extension, so the same compiled binary can accept any mix of formats at runtime (e.g. `--config-file prod.json` today, `--config-file prod.yaml` tomorrow, no rebuild required).
+
+The simple form registers only an unmarshal function:
 
 ```go
 import "gopkg.in/yaml.v3"
@@ -191,13 +193,46 @@ boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 ```
 
-Resolution order for unmarshal function:
+The full form additionally provides a `KeyTree` probe that lets BOA detect *which keys were mentioned* in a config file, even when the written values are zero-valued or equal to the parameter's default. This matters for [optional struct-pointer parameter groups](#optional-parameter-groups):
 
-1. Explicit `ConfigUnmarshal` on the command
-2. Registered format matched by file extension
-3. `json.Unmarshal` (default fallback)
+```go
+boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
+    Unmarshal: yaml.Unmarshal,
+    KeyTree: func(data []byte) (map[string]any, error) {
+        var out map[string]any
+        if err := yaml.Unmarshal(data, &out); err != nil {
+            return nil, err
+        }
+        return out, nil
+    },
+})
+```
 
-You can also set `ConfigUnmarshal` directly on a command to override all format detection for that command:
+Without a `KeyTree`, BOA falls back to snapshot comparison — it detects *changed* values but not zero-value or same-as-default writes. For plain fields and non-pointer substructs the simple form is enough; for optional struct-pointer groups, prefer the full form. `KeyTree` accepts nested maps in either `map[string]any` (yaml.v3, json) or `map[any]any` (yaml.v2) shape.
+
+Resolution order for each config file load:
+
+1. `Cmd.ConfigFormat` — per-command escape hatch; locks that one command to a single format (rarely what you want)
+2. `Cmd.ConfigUnmarshal` — legacy, unmarshal-only, also command-locked
+3. **Registered format matched by file extension — the default path; any number of formats can coexist in one binary**
+4. Built-in JSON fallback
+
+#### Per-command escape hatch
+
+Setting a format directly on a command **bypasses** the extension registry and locks that command to one format. This is almost never what you want — prefer the global registry so your binary stays format-agnostic — but the escape hatch exists for custom-extension blobs from legacy systems and for injecting fake parsers in tests.
+
+```go
+boa.CmdT[Params]{
+    Use: "ingest-legacy-blob",
+    ConfigFormat: boa.ConfigFormat{
+        Unmarshal: myLegacyUnmarshal,
+        // KeyTree optional
+    },
+    RunFunc: func(p *Params, cmd *cobra.Command, args []string) { ... },
+}.Run()
+```
+
+The legacy unmarshal-only field still works:
 
 ```go
 boa.CmdT[Params]{

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -193,7 +193,7 @@ boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 ```
 
-The full form additionally provides a `KeyTree` probe that lets BOA detect *which keys were mentioned* in a config file, even when the written values are zero-valued or equal to the parameter's default. This matters for [optional struct-pointer parameter groups](#optional-parameter-groups):
+The full form additionally provides a `KeyTree` probe that lets BOA detect *which keys were mentioned* in a config file, even when the written values are zero-valued or equal to the parameter's default. This matters for optional struct-pointer parameter groups (`DB *DBConfig`) — without a `KeyTree`, snapshot comparison can't tell "user wrote the default" apart from "user wrote nothing":
 
 ```go
 boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -184,7 +184,7 @@ CLI and env var values always take precedence over config file values.
 
 JSON is the only format shipped by default. BOA has no third-party parser dependencies — you bring your own library and register it in the global registry. The registry is keyed by file extension, so the same compiled binary can accept any mix of formats at runtime (e.g. `--config-file prod.json` today, `--config-file prod.yaml` tomorrow, no rebuild required).
 
-The simple form registers only an unmarshal function:
+#### The one-liner
 
 ```go
 import "gopkg.in/yaml.v3"
@@ -193,22 +193,36 @@ boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 ```
 
-The full form additionally provides a `KeyTree` probe that lets BOA detect *which keys were mentioned* in a config file, even when the written values are zero-valued or equal to the parameter's default. This matters for optional struct-pointer parameter groups (`DB *DBConfig`) — without a `KeyTree`, snapshot comparison can't tell "user wrote the default" apart from "user wrote nothing":
+That's the whole story for every mainstream Go config parser. The one-liner gets you both parsing **and** full key-presence detection — including zero-valued and same-as-default writes to optional struct-pointer parameter groups (`DB *DBConfig`). Under the hood `RegisterConfigFormat` wraps the unmarshaler in a `UniversalConfigFormat`, which asks the same parser to also decode the file into a `map[string]any` so BOA can read the literal key structure. Every mainstream Go parser supports that.
+
+Without a `KeyTree`, BOA would fall back to snapshot comparison for those struct-pointer groups, which can't tell "user wrote the default" apart from "user wrote nothing". With the auto-synthesized one you avoid that gap entirely.
+
+`KeyTree` accepts nested maps in either `map[string]any` (yaml.v3, json, toml) or `map[any]any` (yaml.v2) shape — BOA coerces transparently.
+
+#### The `UniversalConfigFormat` helper
+
+Use it when you want to attach a format inline to `Cmd.ConfigFormat` without touching the global registry:
 
 ```go
-boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
-    Unmarshal: yaml.Unmarshal,
-    KeyTree: func(data []byte) (map[string]any, error) {
-        var out map[string]any
-        if err := yaml.Unmarshal(data, &out); err != nil {
-            return nil, err
-        }
-        return out, nil
-    },
-})
+boa.CmdT[Params]{
+    Use:          "app",
+    ConfigFormat: boa.UniversalConfigFormat(yaml.Unmarshal),
+    RunFunc:      func(p *Params, cmd *cobra.Command, args []string) { ... },
+}.Run()
 ```
 
-Without a `KeyTree`, BOA falls back to snapshot comparison — it detects *changed* values but not zero-value or same-as-default writes. For plain fields and non-pointer substructs the simple form is enough; for optional struct-pointer groups, prefer the full form. `KeyTree` accepts nested maps in either `map[string]any` (yaml.v3, json) or `map[any]any` (yaml.v2) shape.
+`UniversalConfigFormat(nil)` panics, so typos surface at the construction site rather than silently falling through to the JSON handler at parse time.
+
+#### When to reach for `RegisterConfigFormatFull`
+
+Only when your parser **cannot** decode into `map[string]any`. Most of the time, "write a parser that fills only specific struct types" is an app-specific custom format, not a third-party library. In that case the auto-synthesized `KeyTree` would fail at parse time, so you hand-write it yourself:
+
+```go
+boa.RegisterConfigFormatFull(".mycustom", boa.ConfigFormat{
+    Unmarshal: mycustom.Decode,
+    KeyTree:   mycustom.KeysOnly, // returns map[string]any of key structure
+})
+```
 
 Resolution order for each config file load:
 

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -236,6 +236,23 @@ JSON is the only format built in. BOA has no third-party parser dependencies —
 
 The primary model is **register once, dispatch by file extension**. Register every format your app might ever load at startup, and BOA picks the right parser for each `--config-file` argument at runtime. The same compiled binary transparently handles JSON today and YAML tomorrow — there is no per-command locking.
 
+### The One-Liner
+
+For every mainstream Go config parser (`yaml.Unmarshal`, `toml.Unmarshal`, `hcl.Decode`, `json.Unmarshal`, …), a single call is all you need:
+
+```go
+boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+boa.RegisterConfigFormat(".yml",  yaml.Unmarshal)
+boa.RegisterConfigFormat(".toml", toml.Unmarshal)
+```
+
+That one call gets you:
+
+1. **Parsing** — the extension now dispatches to your library's unmarshal function.
+2. **Key-presence detection** — including zero-valued and same-as-default writes to optional struct-pointer parameter groups (see ["Why key-presence detection matters"](#why-key-presence-detection-matters) below for what that means in practice).
+
+The second one comes from a helper called [`UniversalConfigFormat`](#the-universalconfigformat-helper) that `RegisterConfigFormat` uses under the hood: it asks the same parser to additionally decode the file into a `map[string]any`, which is how BOA reads the literal key structure. Every mainstream Go parser can do that, so this all works transparently.
+
 ### Register Multiple Formats, Dispatch by Extension
 
 ```go
@@ -255,9 +272,9 @@ type Params struct {
 }
 
 func init() {
-    // Register any non-JSON formats the binary should accept. JSON is
-    // registered by default, so this single call is enough to support both
-    // .yaml and .json files for the rest of the program's lifetime.
+    // One line per non-JSON format. JSON is registered by default, so the
+    // binary now handles .yaml, .yml, AND .json transparently — dispatch
+    // is decided per --config-file invocation by filepath.Ext.
     boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
     boa.RegisterConfigFormat(".yml", yaml.Unmarshal)
 }
@@ -290,35 +307,9 @@ BOA picks the parser per-call from `filepath.Ext(filePath)`, so there is no glob
 
 > A complete runnable template — using a trivial dep-free "KV" format so the example doesn't drag a YAML/TOML dependency into this repo — lives at [`internal/example_custom_config_format`](https://github.com/GiGurra/boa/tree/main/internal/example_custom_config_format). Its tests load **both** a `.json` file and a `.kv` file through the same `main()`, proving the multi-format-per-binary story end-to-end. Swap the KV functions for `yaml.Unmarshal` + a yaml-backed `KeyTree` and you have the YAML example verbatim.
 
-### Full Registration (Unmarshal + KeyTree) for Struct-Pointer Groups
+### Why Key-Presence Detection Matters
 
-`RegisterConfigFormat` tells BOA how to *parse* the file. That is enough for plain fields and non-pointer substructs. If your app also uses **optional struct-pointer parameter groups** (`DB *DBConfig`) and you want BOA to detect when those groups were mentioned in a config file with only zero-valued or default-matching writes, register the *full* `ConfigFormat` with a `KeyTree` probe instead:
-
-```go
-package main
-
-import (
-    "github.com/GiGurra/boa/pkg/boa"
-    "gopkg.in/yaml.v3"
-)
-
-func init() {
-    boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
-        Unmarshal: yaml.Unmarshal,
-        KeyTree: func(data []byte) (map[string]any, error) {
-            var out map[string]any
-            if err := yaml.Unmarshal(data, &out); err != nil {
-                return nil, err
-            }
-            return out, nil
-        },
-    })
-}
-```
-
-Dispatch still happens by extension; `RegisterConfigFormatFull` just registers a richer handler under the same key. Your binary keeps accepting any mix of registered formats.
-
-Why bother with a `KeyTree`? Consider:
+Consider:
 
 ```go
 type DBConfig struct {
@@ -342,7 +333,27 @@ DB:
 
 Without a `KeyTree`, BOA falls back to snapshot comparison — it compares struct values before and after loading. Those writes don't change anything, so BOA concludes "nothing set" and `p.DB` is nil'd back out after cleanup. With a `KeyTree`, BOA sees the literal key structure, recognises that `DB`, `DB.Host`, and `DB.Port` were mentioned, and keeps the pointer group alive.
 
-This matters only for struct-pointer groups; plain fields and non-pointer substructs work with either form.
+This matters only for struct-pointer parameter groups; plain fields and non-pointer substructs work with either form. `RegisterConfigFormat` already wires up the `KeyTree` for you whenever the parser can decode into `map[string]any` — which is every mainstream Go parser.
+
+### The `UniversalConfigFormat` Helper
+
+`RegisterConfigFormat` uses it internally; you only ever call it directly when you want to set a format inline on `Cmd.ConfigFormat`:
+
+```go
+boa.CmdT[Params]{
+    Use:          "server",
+    ConfigFormat: boa.UniversalConfigFormat(yaml.Unmarshal),
+    RunFunc: func(p *Params, cmd *cobra.Command, args []string) { ... },
+}.Run()
+```
+
+`UniversalConfigFormat(fn)` returns a `ConfigFormat` whose `Unmarshal` is `fn` and whose `KeyTree` invokes the same `fn` against a `map[string]any` target. That's enough for every parser that treats `any`/`interface{}` targets uniformly — i.e. every mainstream Go config library. Passing `nil` panics, so typos surface immediately.
+
+### When You Genuinely Need the Full Form
+
+Reach for the verbose `boa.ConfigFormat{Unmarshal: ..., KeyTree: ...}` literal (and `RegisterConfigFormatFull`) only when your parser **cannot** decode into `map[string]any` — for example, a custom format whose unmarshaler only knows how to populate specific struct types. In that case you have to hand-write the `KeyTree` yourself because `UniversalConfigFormat` would fail at parse time.
+
+The runnable example at [`internal/example_custom_config_format`](https://github.com/GiGurra/boa/tree/main/internal/example_custom_config_format) shows exactly this case: a tiny KV format whose `kvUnmarshal` only populates structs, so it registers via `RegisterConfigFormatFull` with a hand-written `kvKeyTree`. If you're using a mainstream library like `yaml.v3`, you'll never write code that looks like that — `RegisterConfigFormat(".yaml", yaml.Unmarshal)` is all you need.
 
 > `KeyTree` can return nested maps as either `map[string]any` (yaml.v3, json) or `map[any]any` (yaml.v2) — BOA coerces transparently.
 

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -232,7 +232,11 @@ Priority for substruct values: **CLI > env > root config > substruct config > de
 
 ## Config Format Registry
 
-JSON is the only format built in. Register additional formats with `boa.RegisterConfigFormat`.
+JSON is the only format built in. BOA has no third-party parser dependencies — you bring your own library (`gopkg.in/yaml.v3`, `github.com/BurntSushi/toml`, …) and register it.
+
+The primary model is **register once, dispatch by file extension**. Register every format your app might ever load at startup, and BOA picks the right parser for each `--config-file` argument at runtime. The same compiled binary transparently handles JSON today and YAML tomorrow — there is no per-command locking.
+
+### Register Multiple Formats, Dispatch by Extension
 
 ```go
 package main
@@ -245,19 +249,23 @@ import (
 )
 
 type Params struct {
-    ConfigFile string `configfile:"true" optional:"true" default:"config.yaml"`
-    Host       string `descr:"Server host"`
+    ConfigFile string `configfile:"true" optional:"true"`
+    Host       string `descr:"Server host" default:"localhost"`
     Port       int    `descr:"Server port" default:"8080"`
 }
 
-func main() {
-    // Register YAML support -- file extension determines which unmarshal to use
+func init() {
+    // Register any non-JSON formats the binary should accept. JSON is
+    // registered by default, so this single call is enough to support both
+    // .yaml and .json files for the rest of the program's lifetime.
     boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
     boa.RegisterConfigFormat(".yml", yaml.Unmarshal)
+}
 
+func main() {
     boa.CmdT[Params]{
         Use:   "server",
-        Short: "Server with YAML config",
+        Short: "Server that accepts either JSON or YAML config files",
         RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
             fmt.Printf("Host: %s, Port: %d\n", p.Host, p.Port)
         },
@@ -265,41 +273,103 @@ func main() {
 }
 ```
 
-Create `config.yaml`:
-
-```yaml
-Host: api.example.com
-Port: 3000
-```
+The same binary handles all three of these without any code change:
 
 ```bash
-$ go run .
-Host: api.example.com, Port: 3000
+# Production deploy today: JSON
+$ ./server --config-file prod.json
 
-# Can also use JSON files -- BOA picks the right parser by extension:
-$ go run . --config-file config.json
-Host: ...
+# Production redeploy tomorrow: YAML, same binary, just a different argument
+$ ./server --config-file prod.yaml
+
+# Ops-style one-off with a YAML sidecar file
+$ ./server --config-file /etc/myapp/overrides.yml
 ```
 
-### Override Unmarshal Per Command
+BOA picks the parser per-call from `filepath.Ext(filePath)`, so there is no global "current format" and no rebuild required to switch.
 
-Use `ConfigUnmarshal` on the command to bypass file extension detection entirely:
+> A complete runnable template — using a trivial dep-free "KV" format so the example doesn't drag a YAML/TOML dependency into this repo — lives at [`internal/example_custom_config_format`](https://github.com/GiGurra/boa/tree/main/internal/example_custom_config_format). Its tests load **both** a `.json` file and a `.kv` file through the same `main()`, proving the multi-format-per-binary story end-to-end. Swap the KV functions for `yaml.Unmarshal` + a yaml-backed `KeyTree` and you have the YAML example verbatim.
+
+### Full Registration (Unmarshal + KeyTree) for Struct-Pointer Groups
+
+`RegisterConfigFormat` tells BOA how to *parse* the file. That is enough for plain fields and non-pointer substructs. If your app also uses **optional struct-pointer parameter groups** (`DB *DBConfig`) and you want BOA to detect when those groups were mentioned in a config file with only zero-valued or default-matching writes, register the *full* `ConfigFormat` with a `KeyTree` probe instead:
+
+```go
+package main
+
+import (
+    "github.com/GiGurra/boa/pkg/boa"
+    "gopkg.in/yaml.v3"
+)
+
+func init() {
+    boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
+        Unmarshal: yaml.Unmarshal,
+        KeyTree: func(data []byte) (map[string]any, error) {
+            var out map[string]any
+            if err := yaml.Unmarshal(data, &out); err != nil {
+                return nil, err
+            }
+            return out, nil
+        },
+    })
+}
+```
+
+Dispatch still happens by extension; `RegisterConfigFormatFull` just registers a richer handler under the same key. Your binary keeps accepting any mix of registered formats.
+
+Why bother with a `KeyTree`? Consider:
+
+```go
+type DBConfig struct {
+    Host string `descr:"db host" default:"localhost"`
+    Port int    `descr:"db port" default:"5432"`
+}
+
+type Params struct {
+    ConfigFile string `configfile:"true" optional:"true"`
+    DB         *DBConfig // optional parameter group
+}
+```
+
+With this `config.yaml`:
+
+```yaml
+DB:
+  Host: ""     # zero value
+  Port: 5432   # same as the default
+```
+
+Without a `KeyTree`, BOA falls back to snapshot comparison — it compares struct values before and after loading. Those writes don't change anything, so BOA concludes "nothing set" and `p.DB` is nil'd back out after cleanup. With a `KeyTree`, BOA sees the literal key structure, recognises that `DB`, `DB.Host`, and `DB.Port` were mentioned, and keeps the pointer group alive.
+
+This matters only for struct-pointer groups; plain fields and non-pointer substructs work with either form.
+
+> `KeyTree` can return nested maps as either `map[string]any` (yaml.v3, json) or `map[any]any` (yaml.v2) — BOA coerces transparently.
+
+### Per-Command Override (Escape Hatch)
+
+Setting a format on `Cmd.ConfigFormat` (or the legacy `ConfigUnmarshal`) **bypasses** the extension registry for that one command and locks it to a single format. That is almost never what you want — prefer the registry so the same binary stays format-agnostic — but the escape hatch is there for niche cases like:
+
+- A command that must accept a custom-extension blob from a legacy system.
+- Tests that want to inject a fake parser without polluting the global registry.
 
 ```go
 boa.CmdT[Params]{
-    Use:             "server",
-    ConfigUnmarshal: yaml.Unmarshal,  // Always use YAML regardless of file extension
-    RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
-        // ...
+    Use: "ingest-legacy-blob",
+    ConfigFormat: boa.ConfigFormat{
+        Unmarshal: myLegacyUnmarshal,
+        // KeyTree optional
     },
+    RunFunc: func(p *Params, cmd *cobra.Command, args []string) { ... },
 }.Run()
 ```
 
-Resolution order for choosing the unmarshal function:
+Resolution order for each `loadConfigFileInto` call:
 
-1. Explicit `ConfigUnmarshal` on the command
-2. Registered format matched by file extension (`.yaml` -> `yaml.Unmarshal`)
-3. `json.Unmarshal` (default fallback)
+1. `Cmd.ConfigFormat` (if `Unmarshal` is non-nil) — locks this one command to a single format
+2. `Cmd.ConfigUnmarshal` (legacy; unmarshal-only, also command-locked)
+3. Format registered by file extension — **the default path; supports any number of formats in one binary**
+4. Built-in JSON fallback (with `KeyTree`)
 
 ## Config-File-Only Fields (`boa:"ignore"`)
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -223,7 +223,10 @@ boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
     Unmarshal: yaml.Unmarshal,
     KeyTree: func(data []byte) (map[string]any, error) {
         var out map[string]any
-        return out, yaml.Unmarshal(data, &out)
+        if err := yaml.Unmarshal(data, &out); err != nil {
+            return nil, err
+        }
+        return out, nil
     },
 })
 ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -213,11 +213,22 @@ type Params struct {
 Register custom config file formats by extension. JSON is the only format shipped by default:
 
 ```go
+// Simple: unmarshal only (falls back to snapshot comparison for set-by-config detection)
 boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 boa.RegisterConfigFormat(".toml", toml.Unmarshal)
+
+// Full: unmarshal + KeyTree probe (required to detect zero-value or
+// same-as-default writes to optional struct-pointer parameter groups)
+boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
+    Unmarshal: yaml.Unmarshal,
+    KeyTree: func(data []byte) (map[string]any, error) {
+        var out map[string]any
+        return out, yaml.Unmarshal(data, &out)
+    },
+})
 ```
 
-Resolution: explicit `ConfigUnmarshal` on the command > registered format by file extension > `json.Unmarshal` fallback.
+Resolution: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > registered format by extension > `json.Unmarshal` fallback. See the [Config Format Registry section in Advanced Usage](advanced.md#config-format-registry) for details on when to prefer the full form.
 
 #### Named Struct Auto-Prefixing
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -213,25 +213,16 @@ type Params struct {
 Register custom config file formats by extension. JSON is the only format shipped by default:
 
 ```go
-// Simple: unmarshal only (falls back to snapshot comparison for set-by-config detection)
+// One line per format — works for every mainstream Go config parser.
+// Key-presence detection (including zero-value and same-as-default writes
+// to optional struct-pointer parameter groups) is enabled automatically.
 boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 boa.RegisterConfigFormat(".toml", toml.Unmarshal)
-
-// Full: unmarshal + KeyTree probe (required to detect zero-value or
-// same-as-default writes to optional struct-pointer parameter groups)
-boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
-    Unmarshal: yaml.Unmarshal,
-    KeyTree: func(data []byte) (map[string]any, error) {
-        var out map[string]any
-        if err := yaml.Unmarshal(data, &out); err != nil {
-            return nil, err
-        }
-        return out, nil
-    },
-})
 ```
 
-Resolution: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > registered format by extension > `json.Unmarshal` fallback. See the [Config Format Registry section in Advanced Usage](advanced.md#config-format-registry) for details on when to prefer the full form.
+`RegisterConfigFormat` wraps the unmarshal function in a `boa.UniversalConfigFormat`, which synthesizes the `KeyTree` probe by asking the same parser to decode into a `map[string]any`. For inline per-command overrides you can call the helper directly: `ConfigFormat: boa.UniversalConfigFormat(yaml.Unmarshal)`. Only drop to the explicit `boa.ConfigFormat{Unmarshal: ..., KeyTree: ...}` literal (via `RegisterConfigFormatFull`) when your parser genuinely cannot decode into `map[string]any` — that is almost never a third-party library, only a handwritten custom format.
+
+Resolution: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > registered format by extension > `json.Unmarshal` fallback. See the [Config Format Registry section in Advanced Usage](advanced.md#config-format-registry) for details.
 
 #### Named Struct Auto-Prefixing
 

--- a/internal/example_custom_config_format/main.go
+++ b/internal/example_custom_config_format/main.go
@@ -1,0 +1,198 @@
+// Example: registering a custom config file format (unmarshal + KeyTree) so
+// that the *same compiled binary* can load config files in any registered
+// format — JSON (built in), a custom "KV" format (registered here), and by
+// extension anything else you plug in.
+//
+// The command does not lock itself to a single format. boa dispatches at
+// runtime based on the file extension of the --config-file argument, so:
+//
+//	./server --config-file prod.json   # uses the built-in JSON handler
+//	./server --config-file prod.kv     # uses the handler registered here
+//
+// Switching formats in production is just a different --config-file; no
+// code change, no rebuild.
+//
+// This example uses a trivially small "KV" format for illustration only. In a
+// real application you would substitute the unmarshal/KeyTree functions for
+// your favourite parser (gopkg.in/yaml.v3, github.com/BurntSushi/toml, …) and
+// keep boa itself free of that dependency.
+//
+// The config file looks like:
+//
+//	host = db.internal
+//	port = 5432
+//	db.host =
+//	db.port = 5432
+//
+// Lines are "key = value", with "." introducing nesting. Quotes/escapes are
+// intentionally ignored; the point is to show the ConfigFormat integration,
+// not to ship a production parser.
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/GiGurra/boa/pkg/boa"
+	"github.com/spf13/cobra"
+)
+
+type DBConfig struct {
+	Host string `descr:"database host" default:"localhost"`
+	Port int    `descr:"database port" default:"5432"`
+}
+
+type Params struct {
+	ConfigFile string `configfile:"true" optional:"true"`
+	Host       string `descr:"app host" default:"localhost"`
+	Port       int    `descr:"app port" default:"8080"`
+	// Optional parameter group. The .kv format's KeyTree probe lets boa
+	// see that "db.host" and "db.port" are written even when they equal
+	// the zero value / the default — so this pointer survives cleanup.
+	DB *DBConfig
+}
+
+// parseKV returns the key/value pairs and a nested key tree that mirrors
+// the dotted-path structure. It deliberately shares work between Unmarshal
+// and KeyTree in real code you would split them if the parser is expensive.
+func parseKV(data []byte) (flat map[string]string, tree map[string]any, err error) {
+	flat = map[string]string{}
+	tree = map[string]any{}
+	for lineNo, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			return nil, nil, fmt.Errorf("line %d: missing '='", lineNo+1)
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		flat[key] = val
+
+		// Walk the dotted path in the tree, creating sub-maps on the way.
+		segments := strings.Split(key, ".")
+		cursor := tree
+		for i, seg := range segments {
+			if i == len(segments)-1 {
+				cursor[seg] = val
+				break
+			}
+			next, ok := cursor[seg].(map[string]any)
+			if !ok {
+				next = map[string]any{}
+				cursor[seg] = next
+			}
+			cursor = next
+		}
+	}
+	return flat, tree, nil
+}
+
+// kvUnmarshal populates `target` from the parsed KV pairs using reflection.
+// Top-level keys map onto struct fields; dotted keys descend into sub-structs.
+func kvUnmarshal(data []byte, target any) error {
+	flat, _, err := parseKV(data)
+	if err != nil {
+		return err
+	}
+	root := reflect.ValueOf(target).Elem()
+	for key, val := range flat {
+		if err := assignDotted(root, strings.Split(key, "."), val); err != nil {
+			return fmt.Errorf("key %q: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func assignDotted(v reflect.Value, segments []string, val string) error {
+	if len(segments) == 0 {
+		return nil
+	}
+	field := lookupField(v, segments[0])
+	if !field.IsValid() {
+		return nil // unknown key — ignore
+	}
+	// Follow a pointer-to-struct if present (boa preallocates these for
+	// optional parameter groups, so deref is always safe here).
+	if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
+		if field.IsNil() {
+			field.Set(reflect.New(field.Type().Elem()))
+		}
+		field = field.Elem()
+	}
+	if len(segments) > 1 {
+		return assignDotted(field, segments[1:], val)
+	}
+	return setScalar(field, val)
+}
+
+func lookupField(v reflect.Value, name string) reflect.Value {
+	if v.Kind() != reflect.Struct {
+		return reflect.Value{}
+	}
+	if f := v.FieldByName(name); f.IsValid() {
+		return f
+	}
+	// Case-insensitive fallback, matching encoding/json behaviour.
+	for i := 0; i < v.NumField(); i++ {
+		if strings.EqualFold(v.Type().Field(i).Name, name) {
+			return v.Field(i)
+		}
+	}
+	return reflect.Value{}
+}
+
+func setScalar(f reflect.Value, val string) error {
+	switch f.Kind() {
+	case reflect.String:
+		f.SetString(val)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		f.SetInt(n)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return err
+		}
+		f.SetBool(b)
+	}
+	return nil
+}
+
+// kvKeyTree returns the nested key tree boa needs for set-by-config detection.
+// Scalar leaf values come through as plain strings; boa only inspects presence.
+func kvKeyTree(data []byte) (map[string]any, error) {
+	_, tree, err := parseKV(data)
+	return tree, err
+}
+
+func main() {
+	// Register the custom format as if it were yaml/toml. boa uses the
+	// file extension to dispatch; Cmd.ConfigFormat can override per-command.
+	boa.RegisterConfigFormatFull(".kv", boa.ConfigFormat{
+		Unmarshal: kvUnmarshal,
+		KeyTree:   kvKeyTree,
+	})
+
+	boa.CmdT[Params]{
+		Use:         "server",
+		Short:       "Server with a custom config file format",
+		ParamEnrich: boa.ParamEnricherName,
+		RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+			fmt.Printf("Host: %s, Port: %d\n", p.Host, p.Port)
+			if p.DB == nil {
+				fmt.Println("DB: <unset>")
+				return
+			}
+			fmt.Printf("DB.Host: %q (set by config: %t)\n", p.DB.Host, ctx.HasValue(&p.DB.Host))
+			fmt.Printf("DB.Port: %d (set by config: %t)\n", p.DB.Port, ctx.HasValue(&p.DB.Port))
+		},
+	}.Run()
+}

--- a/internal/example_custom_config_format/main.go
+++ b/internal/example_custom_config_format/main.go
@@ -173,26 +173,53 @@ func kvKeyTree(data []byte) (map[string]any, error) {
 	return tree, err
 }
 
-func main() {
-	// Register the custom format as if it were yaml/toml. boa uses the
-	// file extension to dispatch; Cmd.ConfigFormat can override per-command.
-	boa.RegisterConfigFormatFull(".kv", boa.ConfigFormat{
-		Unmarshal: kvUnmarshal,
-		KeyTree:   kvKeyTree,
-	})
+// Observed records what each RunFuncCtx invocation saw — used by the tests to
+// assert on the actual parsed state instead of just exit status.
+type Observed struct {
+	Host         string
+	Port         int
+	DBPresent    bool
+	DBHost       string
+	DBPort       int
+	DBHostViaCfg bool
+	DBPortViaCfg bool
+}
 
-	boa.CmdT[Params]{
+// newServerCmd builds the command and wires it to capture the parsed state.
+// It is the testable entry point; main() just runs the same builder.
+func newServerCmd(obs *Observed) boa.CmdT[Params] {
+	return boa.CmdT[Params]{
 		Use:         "server",
 		Short:       "Server with a custom config file format",
 		ParamEnrich: boa.ParamEnricherName,
 		RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+			obs.Host, obs.Port = p.Host, p.Port
 			fmt.Printf("Host: %s, Port: %d\n", p.Host, p.Port)
 			if p.DB == nil {
 				fmt.Println("DB: <unset>")
 				return
 			}
-			fmt.Printf("DB.Host: %q (set by config: %t)\n", p.DB.Host, ctx.HasValue(&p.DB.Host))
-			fmt.Printf("DB.Port: %d (set by config: %t)\n", p.DB.Port, ctx.HasValue(&p.DB.Port))
+			obs.DBPresent = true
+			obs.DBHost, obs.DBPort = p.DB.Host, p.DB.Port
+			obs.DBHostViaCfg = ctx.HasValue(&p.DB.Host)
+			obs.DBPortViaCfg = ctx.HasValue(&p.DB.Port)
+			fmt.Printf("DB.Host: %q (set by config: %t)\n", p.DB.Host, obs.DBHostViaCfg)
+			fmt.Printf("DB.Port: %d (set by config: %t)\n", p.DB.Port, obs.DBPortViaCfg)
 		},
-	}.Run()
+	}
+}
+
+// registerKVFormat registers the custom .kv format. Separated from main() so
+// tests can call it exactly once via sync.Once semantics at package level.
+func registerKVFormat() {
+	boa.RegisterConfigFormatFull(".kv", boa.ConfigFormat{
+		Unmarshal: kvUnmarshal,
+		KeyTree:   kvKeyTree,
+	})
+}
+
+func main() {
+	registerKVFormat()
+	var obs Observed
+	newServerCmd(&obs).Run()
 }

--- a/internal/example_custom_config_format/main_test.go
+++ b/internal/example_custom_config_format/main_test.go
@@ -1,38 +1,95 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 )
+
+// registerOnce keeps the global format registration idempotent across tests.
+var registerOnce sync.Once
 
 func testdataPath(name string) string {
 	_, file, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(file), "testdata", name)
 }
 
-// TestCustomFormatRoundTrip loads the custom .kv format via the extension registry.
-func TestCustomFormatRoundTrip(t *testing.T) {
-	prev := os.Args
-	defer func() { os.Args = prev }()
-	os.Args = []string{"server", "--config-file", testdataPath("config.kv")}
-	main()
+// runWith drives the command via RunArgsE (not main()), captures the parsed
+// state via the Observed struct, and surfaces any error to the test.
+func runWith(t *testing.T, args ...string) Observed {
+	t.Helper()
+	registerOnce.Do(registerKVFormat)
+	var obs Observed
+	cmd := newServerCmd(&obs)
+	if err := cmd.RunArgsE(args); err != nil {
+		t.Fatalf("RunArgsE(%v): %v", args, err)
+	}
+	return obs
 }
 
-// TestBuiltinJSONSameBinary loads a .json file using the same compiled binary,
+// TestCustomFormatRoundTrip proves the custom .kv format is dispatched via the
+// extension registry and that every field in the config file makes it into
+// the parsed struct, including optional struct-pointer group fields with
+// same-as-default writes.
+func TestCustomFormatRoundTrip(t *testing.T) {
+	got := runWith(t, "--config-file", testdataPath("config.kv"))
+
+	if got.Host != "api.example.com" {
+		t.Errorf("Host = %q, want api.example.com", got.Host)
+	}
+	if got.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", got.Port)
+	}
+	if !got.DBPresent {
+		t.Fatal("DB pointer group should survive cleanup (KeyTree sees same-as-default writes)")
+	}
+	if got.DBHost != "localhost" {
+		t.Errorf("DB.Host = %q, want localhost", got.DBHost)
+	}
+	if got.DBPort != 5432 {
+		t.Errorf("DB.Port = %d, want 5432", got.DBPort)
+	}
+	// Both DB leaves were written with their default values; only a working
+	// KeyTree-based detector can report HasValue=true here.
+	if !got.DBHostViaCfg {
+		t.Error("DB.Host should report set-by-config=true (same-as-default write via KeyTree)")
+	}
+	if !got.DBPortViaCfg {
+		t.Error("DB.Port should report set-by-config=true (same-as-default write via KeyTree)")
+	}
+}
+
+// TestBuiltinJSONSameBinary loads a .json file with the same compiled binary,
 // proving the program is not locked to the custom format just because it
 // registered one. This is the "deploy with json today, yaml tomorrow" scenario.
 func TestBuiltinJSONSameBinary(t *testing.T) {
-	prev := os.Args
-	defer func() { os.Args = prev }()
-	os.Args = []string{"server", "--config-file", testdataPath("config.json")}
-	main()
+	got := runWith(t, "--config-file", testdataPath("config.json"))
+
+	if got.Host != "api.example.com" {
+		t.Errorf("Host = %q, want api.example.com", got.Host)
+	}
+	if got.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", got.Port)
+	}
+	if !got.DBPresent {
+		t.Fatal("DB pointer group should survive cleanup under built-in JSON handler")
+	}
+	if got.DBHost != "localhost" || got.DBPort != 5432 {
+		t.Errorf("DB values mismatch: host=%q port=%d", got.DBHost, got.DBPort)
+	}
 }
 
+// TestCustomFormatCLIOverride asserts that a CLI flag actually overrides the
+// config file value, not just that the program exits cleanly.
 func TestCustomFormatCLIOverride(t *testing.T) {
-	prev := os.Args
-	defer func() { os.Args = prev }()
-	os.Args = []string{"server", "--config-file", testdataPath("config.kv"), "--port", "9999"}
-	main()
+	got := runWith(t, "--config-file", testdataPath("config.kv"), "--port", "9999")
+
+	if got.Port != 9999 {
+		t.Errorf("Port = %d, want 9999 (CLI should override config)", got.Port)
+	}
+	// Config-file Host should still apply since CLI didn't set it.
+	if got.Host != "api.example.com" {
+		t.Errorf("Host = %q, want api.example.com (config file value, CLI didn't override)", got.Host)
+	}
 }

--- a/internal/example_custom_config_format/main_test.go
+++ b/internal/example_custom_config_format/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func testdataPath(name string) string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(file), "testdata", name)
+}
+
+// TestCustomFormatRoundTrip loads the custom .kv format via the extension registry.
+func TestCustomFormatRoundTrip(t *testing.T) {
+	prev := os.Args
+	defer func() { os.Args = prev }()
+	os.Args = []string{"server", "--config-file", testdataPath("config.kv")}
+	main()
+}
+
+// TestBuiltinJSONSameBinary loads a .json file using the same compiled binary,
+// proving the program is not locked to the custom format just because it
+// registered one. This is the "deploy with json today, yaml tomorrow" scenario.
+func TestBuiltinJSONSameBinary(t *testing.T) {
+	prev := os.Args
+	defer func() { os.Args = prev }()
+	os.Args = []string{"server", "--config-file", testdataPath("config.json")}
+	main()
+}
+
+func TestCustomFormatCLIOverride(t *testing.T) {
+	prev := os.Args
+	defer func() { os.Args = prev }()
+	os.Args = []string{"server", "--config-file", testdataPath("config.kv"), "--port", "9999"}
+	main()
+}

--- a/internal/example_custom_config_format/testdata/config.json
+++ b/internal/example_custom_config_format/testdata/config.json
@@ -1,0 +1,8 @@
+{
+  "Host": "api.example.com",
+  "Port": 3000,
+  "DB": {
+    "Host": "localhost",
+    "Port": 5432
+  }
+}

--- a/internal/example_custom_config_format/testdata/config.kv
+++ b/internal/example_custom_config_format/testdata/config.kv
@@ -1,0 +1,7 @@
+host = api.example.com
+port = 3000
+# Explicitly mention the DB group, but write values that equal the defaults.
+# Snapshot comparison alone would not detect these writes; the KeyTree probe
+# lets boa keep the DB pointer group alive and mark both fields as set.
+db.host = localhost
+db.port = 5432

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -671,12 +672,28 @@ func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
 //	    },
 //	})
 func RegisterConfigFormatFull(ext string, format ConfigFormat) {
+	normalized := normalizeConfigExt(ext)
 	if format.Unmarshal == nil {
 		panic(fmt.Errorf("boa: RegisterConfigFormatFull(%q): ConfigFormat.Unmarshal must be non-nil", ext))
 	}
 	configFormatsMu.Lock()
 	defer configFormatsMu.Unlock()
-	configFormats[ext] = format
+	configFormats[normalized] = format
+}
+
+// normalizeConfigExt canonicalises an extension registration key into the
+// dot-prefixed form that filepath.Ext produces at lookup time. Accepts either
+// "yaml" or ".yaml" — both become ".yaml" — so users don't have to remember
+// which form boa expects. An empty string panics because it's unambiguously
+// a programmer mistake.
+func normalizeConfigExt(ext string) string {
+	if ext == "" {
+		panic(fmt.Errorf("boa: config format extension must not be empty"))
+	}
+	if !strings.HasPrefix(ext, ".") {
+		return "." + ext
+	}
+	return ext
 }
 
 // ConfigFormatExtensions returns the file extensions that have registered

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -496,7 +496,12 @@ func SubCmds(cmds ...CmdIfc) []*cobra.Command {
 // LoadConfigFile reads a config file and unmarshals it into the target struct.
 // If filePath is empty, it's a no-op (returns nil).
 // CLI and env var values still take precedence when used in PreValidateFunc.
-// If unmarshalFunc is nil, defaults to json.Unmarshal.
+//
+// If unmarshalFunc is non-nil it is used directly. If unmarshalFunc is nil the
+// resolution order is the same as for configfile:"true" fields: the registered
+// format matching the file's extension first (RegisterConfigFormat /
+// RegisterConfigFormatFull), and json.Unmarshal as the final fallback when no
+// registration matches.
 func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte, any) error) error {
 	override := ConfigFormat{}
 	if unmarshalFunc != nil {

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -556,23 +556,79 @@ func jsonKeyTree(data []byte) (map[string]any, error) {
 	return out, nil
 }
 
-// RegisterConfigFormat registers an unmarshal function for a config file extension.
-// The extension should include the dot (e.g., ".yaml", ".toml").
+// UniversalConfigFormat builds a ConfigFormat from a single "universal"
+// unmarshal function — one that can decode bytes into any target, including
+// map[string]any. The returned ConfigFormat has:
 //
-// This is a convenience wrapper that registers a ConfigFormat containing only
-// Unmarshal. For full control — including the KeyTree probe that lets boa
-// detect zero-valued or default-matching writes to optional struct-pointer
-// groups — use RegisterConfigFormatFull.
+//   - Unmarshal — the function you passed in.
+//   - KeyTree — a synthesized probe that calls the same function against a
+//     map[string]any target so boa can inspect the literal key structure.
 //
-// Registration is not goroutine-safe; call from init() or from main-goroutine
-// startup before any commands run. Passing a nil unmarshalFunc panics.
+// That covers every mainstream Go config parser (encoding/json,
+// gopkg.in/yaml.v3, github.com/BurntSushi/toml, github.com/hashicorp/hcl/v2,
+// …), all of which decode into interface{} targets uniformly.
+//
+// RegisterConfigFormat uses this helper internally, so for registry-based
+// dispatch you normally just call RegisterConfigFormat directly. Call
+// UniversalConfigFormat yourself when you want to set a format inline on a
+// single command via Cmd.ConfigFormat:
+//
+//	boa.CmdT[Params]{
+//	    ConfigFormat: boa.UniversalConfigFormat(yaml.Unmarshal),
+//	    ...
+//	}
+//
+// Use the explicit boa.ConfigFormat{Unmarshal, KeyTree} struct literal (and
+// RegisterConfigFormatFull) only when the parser cannot decode into
+// map[string]any — e.g., a handwritten custom format that only populates
+// specific struct types. In that case supply a KeyTree function that
+// produces the nested key structure yourself.
+//
+// Passing nil panics — a missing unmarshal function is a programming error
+// and is surfaced eagerly so you don't silently fall through to the JSON
+// handler at parse time.
+func UniversalConfigFormat(unmarshalFunc func([]byte, any) error) ConfigFormat {
+	if unmarshalFunc == nil {
+		panic(fmt.Errorf("boa: UniversalConfigFormat: unmarshalFunc must be non-nil"))
+	}
+	return ConfigFormat{
+		Unmarshal: unmarshalFunc,
+		KeyTree: func(data []byte) (map[string]any, error) {
+			var out map[string]any
+			if err := unmarshalFunc(data, &out); err != nil {
+				return nil, err
+			}
+			return out, nil
+		},
+	}
+}
+
+// RegisterConfigFormat registers an unmarshal function for a config file
+// extension. The extension should include the dot (e.g., ".yaml", ".toml").
+//
+// A single call gives you both parsing (the file extension now dispatches to
+// unmarshalFunc) and full key-presence detection (including zero-valued and
+// same-as-default writes to optional struct-pointer parameter groups).
+// Internally, RegisterConfigFormat wraps unmarshalFunc in a
+// UniversalConfigFormat — the KeyTree is synthesized by calling the same
+// parser against a map[string]any target, which every mainstream Go config
+// library supports.
 //
 // Example:
 //
 //	boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 //	boa.RegisterConfigFormat(".toml", toml.Unmarshal)
+//	boa.RegisterConfigFormat(".hcl", hcl.Decode)
+//
+// Registration is not goroutine-safe; call from init() or from main-goroutine
+// startup before any commands run. Passing a nil unmarshalFunc panics.
+//
+// Use RegisterConfigFormatFull instead only when your parser cannot decode
+// into map[string]any (e.g., a custom format that only populates specific
+// struct types). In that case you must supply a hand-written KeyTree that
+// produces the nested key structure yourself.
 func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
-	RegisterConfigFormatFull(ext, ConfigFormat{Unmarshal: unmarshalFunc})
+	RegisterConfigFormatFull(ext, UniversalConfigFormat(unmarshalFunc))
 }
 
 // RegisterConfigFormatFull registers a complete ConfigFormat for a config file

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -559,6 +559,9 @@ func jsonKeyTree(data []byte) (map[string]any, error) {
 // detect zero-valued or default-matching writes to optional struct-pointer
 // groups — use RegisterConfigFormatFull.
 //
+// Registration is not goroutine-safe; call from init() or from main-goroutine
+// startup before any commands run. Passing a nil unmarshalFunc panics.
+//
 // Example:
 //
 //	boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
@@ -573,6 +576,11 @@ func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
 //
 // The extension should include the dot (e.g., ".yaml", ".toml").
 //
+// Registration is not goroutine-safe; call from init() or from main-goroutine
+// startup before any commands run. Passing a ConfigFormat with a nil Unmarshal
+// panics — a missing parser is a programming error and is surfaced eagerly so
+// you don't silently fall through to the JSON handler at parse time.
+//
 // Example (using gopkg.in/yaml.v3):
 //
 //	boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
@@ -586,6 +594,9 @@ func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
 //	    },
 //	})
 func RegisterConfigFormatFull(ext string, format ConfigFormat) {
+	if format.Unmarshal == nil {
+		panic(fmt.Errorf("boa: RegisterConfigFormatFull(%q): ConfigFormat.Unmarshal must be non-nil", ext))
+	}
 	configFormats[ext] = format
 }
 
@@ -630,8 +641,8 @@ func resolveConfigFormat(filePath string, override ConfigFormat) ConfigFormat {
 		return override
 	}
 	ext := filepath.Ext(filePath)
-	if fmt, ok := configFormats[ext]; ok && fmt.Unmarshal != nil {
-		return fmt
+	if cf, ok := configFormats[ext]; ok && cf.Unmarshal != nil {
+		return cf
 	}
 	return ConfigFormat{Unmarshal: json.Unmarshal, KeyTree: jsonKeyTree}
 }

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -76,7 +76,17 @@ type Cmd struct {
 	PreExecuteFuncCtx func(ctx *HookContext, params any, cmd *cobra.Command, args []string) error
 	// ConfigUnmarshal specifies the unmarshal function for config files loaded via the configfile tag.
 	// If nil, defaults to json.Unmarshal.
+	//
+	// For richer support (including key-presence probing that lets boa detect
+	// zero-valued or default-matching writes to optional struct-pointer groups),
+	// prefer the ConfigFormat field, which accepts a full ConfigFormat value.
+	// When both are set, ConfigFormat takes precedence.
 	ConfigUnmarshal func([]byte, any) error
+	// ConfigFormat specifies a per-command config file format — both the
+	// unmarshaler and an optional key-tree probe used for set-by-config detection.
+	// When set, this takes precedence over ConfigUnmarshal and over any format
+	// registered via RegisterConfigFormat for the file extension.
+	ConfigFormat ConfigFormat
 	// RawArgs allows injecting command line arguments instead of using os.Args
 	RawArgs []string
 }
@@ -488,25 +498,95 @@ func SubCmds(cmds ...CmdIfc) []*cobra.Command {
 // CLI and env var values still take precedence when used in PreValidateFunc.
 // If unmarshalFunc is nil, defaults to json.Unmarshal.
 func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte, any) error) error {
-	_, err := loadConfigFileInto(filePath, target, unmarshalFunc)
+	override := ConfigFormat{}
+	if unmarshalFunc != nil {
+		override.Unmarshal = unmarshalFunc
+	}
+	_, _, err := loadConfigFileInto(filePath, target, override)
 	return err
 }
 
-// configFormats maps file extensions to unmarshal functions.
-// JSON is registered by default. Users can register additional formats
-// (e.g., YAML, TOML) via RegisterConfigFormat.
-var configFormats = map[string]func([]byte, any) error{
-	".json": json.Unmarshal,
+// ConfigFormat describes how to parse and introspect a config file format.
+//
+// boa ships with a built-in handler for JSON only. To support other formats
+// (YAML, TOML, HCL, …) without forcing those dependencies on every boa user,
+// bring your own parser and register it via RegisterConfigFormatFull — or set
+// Cmd.ConfigFormat on a single command.
+type ConfigFormat struct {
+	// Unmarshal parses raw bytes into the target struct. Required.
+	Unmarshal func(data []byte, target any) error
+
+	// KeyTree returns a nested map[string]any representing the top-level and
+	// nested key structure of the raw bytes. boa uses this to detect which
+	// struct fields — and which optional struct-pointer parameter groups —
+	// were explicitly mentioned in the config file, even when the written
+	// value equals Go's zero value or the parameter's default.
+	//
+	// Only key presence matters. Nested objects should appear as map[string]any
+	// so boa can recurse; scalars and arrays may be any non-nil placeholder.
+	//
+	// Optional. If nil, boa falls back to snapshot comparison, which detects
+	// changed values but not zero-value or same-as-default writes to optional
+	// struct-pointer parameter groups.
+	KeyTree func(data []byte) (map[string]any, error)
+}
+
+// configFormats maps file extensions to their registered ConfigFormat.
+// JSON is registered by default with both Unmarshal and KeyTree. Users can
+// register additional formats (e.g., YAML, TOML) via RegisterConfigFormat
+// or RegisterConfigFormatFull.
+var configFormats = map[string]ConfigFormat{
+	".json": {
+		Unmarshal: json.Unmarshal,
+		KeyTree:   jsonKeyTree,
+	},
+}
+
+// jsonKeyTree is the built-in KeyTree implementation for JSON.
+func jsonKeyTree(data []byte) (map[string]any, error) {
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // RegisterConfigFormat registers an unmarshal function for a config file extension.
 // The extension should include the dot (e.g., ".yaml", ".toml").
+//
+// This is a convenience wrapper that registers a ConfigFormat containing only
+// Unmarshal. For full control — including the KeyTree probe that lets boa
+// detect zero-valued or default-matching writes to optional struct-pointer
+// groups — use RegisterConfigFormatFull.
+//
 // Example:
 //
 //	boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
 //	boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
-	configFormats[ext] = unmarshalFunc
+	RegisterConfigFormatFull(ext, ConfigFormat{Unmarshal: unmarshalFunc})
+}
+
+// RegisterConfigFormatFull registers a complete ConfigFormat for a config file
+// extension. Use this when you want boa to honour key-presence detection for
+// your format (zero-valued writes, same-as-default writes).
+//
+// The extension should include the dot (e.g., ".yaml", ".toml").
+//
+// Example (using gopkg.in/yaml.v3):
+//
+//	boa.RegisterConfigFormatFull(".yaml", boa.ConfigFormat{
+//	    Unmarshal: yaml.Unmarshal,
+//	    KeyTree: func(data []byte) (map[string]any, error) {
+//	        var out map[string]any
+//	        if err := yaml.Unmarshal(data, &out); err != nil {
+//	            return nil, err
+//	        }
+//	        return out, nil
+//	    },
+//	})
+func RegisterConfigFormatFull(ext string, format ConfigFormat) {
+	configFormats[ext] = format
 }
 
 // ConfigFormatExtensions returns the file extensions that have registered config format handlers.
@@ -520,31 +600,40 @@ func ConfigFormatExtensions() []string {
 }
 
 // loadConfigFileInto is the non-generic implementation used internally.
-// Resolution order for unmarshal function:
-//  1. Explicit unmarshalFunc parameter (from Cmd.ConfigUnmarshal)
-//  2. Registered format based on file extension
-//  3. json.Unmarshal (default fallback)
-func loadConfigFileInto(filePath string, target any, unmarshalFunc func([]byte, any) error) ([]byte, error) {
+// Resolution order for the effective ConfigFormat:
+//  1. override (from Cmd.ConfigFormat / Cmd.ConfigUnmarshal) when its Unmarshal is non-nil
+//  2. Registered format for the file extension
+//  3. JSON fallback (unmarshal + key-tree)
+//
+// Returns the raw bytes and the effective ConfigFormat so callers can reuse
+// its KeyTree for key-presence detection.
+func loadConfigFileInto(filePath string, target any, override ConfigFormat) ([]byte, ConfigFormat, error) {
 	if filePath == "" {
-		return nil, nil
+		return nil, ConfigFormat{}, nil
 	}
 	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+		return nil, ConfigFormat{}, fmt.Errorf("failed to read config file %s: %w", filePath, err)
 	}
-	if unmarshalFunc == nil {
-		// Look up by file extension
-		ext := filepath.Ext(filePath)
-		if fn, ok := configFormats[ext]; ok {
-			unmarshalFunc = fn
-		} else {
-			unmarshalFunc = json.Unmarshal // ultimate fallback
-		}
+	effective := resolveConfigFormat(filePath, override)
+	if err := effective.Unmarshal(fileContents, target); err != nil {
+		return nil, effective, fmt.Errorf("failed to unmarshal config file %s: %w", filePath, err)
 	}
-	if err := unmarshalFunc(fileContents, target); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config file %s: %w", filePath, err)
+	return fileContents, effective, nil
+}
+
+// resolveConfigFormat picks the ConfigFormat to use for a given file, honouring
+// the precedence override → extension-registered → JSON fallback. The returned
+// ConfigFormat always has a non-nil Unmarshal.
+func resolveConfigFormat(filePath string, override ConfigFormat) ConfigFormat {
+	if override.Unmarshal != nil {
+		return override
 	}
-	return fileContents, nil
+	ext := filepath.Ext(filePath)
+	if fmt, ok := configFormats[ext]; ok && fmt.Unmarshal != nil {
+		return fmt
+	}
+	return ConfigFormat{Unmarshal: json.Unmarshal, KeyTree: jsonKeyTree}
 }
 
 // UnMarshalFromFileParam reads a file path from a parameter and unmarshals its contents into a target struct.

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
+	"sync"
 
 	"github.com/spf13/cobra"
 )
@@ -540,12 +542,20 @@ type ConfigFormat struct {
 // JSON is registered by default with both Unmarshal and KeyTree. Users can
 // register additional formats (e.g., YAML, TOML) via RegisterConfigFormat
 // or RegisterConfigFormatFull.
-var configFormats = map[string]ConfigFormat{
-	".json": {
-		Unmarshal: json.Unmarshal,
-		KeyTree:   jsonKeyTree,
-	},
-}
+//
+// Access to configFormats MUST go through configFormatsMu. Registration
+// (write) takes the exclusive lock; resolution / extension enumeration take
+// the read lock. The read path is hot — every config file load hits it —
+// but it's a pure map lookup so RWMutex contention is negligible in practice.
+var (
+	configFormatsMu sync.RWMutex
+	configFormats   = map[string]ConfigFormat{
+		".json": {
+			Unmarshal: json.Unmarshal,
+			KeyTree:   jsonKeyTree,
+		},
+	}
+)
 
 // jsonKeyTree is the built-in KeyTree implementation for JSON.
 func jsonKeyTree(data []byte) (map[string]any, error) {
@@ -620,8 +630,10 @@ func UniversalConfigFormat(unmarshalFunc func([]byte, any) error) ConfigFormat {
 //	boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 //	boa.RegisterConfigFormat(".hcl", hcl.Decode)
 //
-// Registration is not goroutine-safe; call from init() or from main-goroutine
-// startup before any commands run. Passing a nil unmarshalFunc panics.
+// Registration is goroutine-safe (the registry is guarded by a
+// sync.RWMutex), but the common pattern is still to call from init() or
+// from main-goroutine startup before any commands run. Passing a nil
+// unmarshalFunc panics.
 //
 // Use RegisterConfigFormatFull instead only when your parser cannot decode
 // into map[string]any (e.g., a custom format that only populates specific
@@ -632,15 +644,19 @@ func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error) {
 }
 
 // RegisterConfigFormatFull registers a complete ConfigFormat for a config file
-// extension. Use this when you want boa to honour key-presence detection for
-// your format (zero-valued writes, same-as-default writes).
+// extension. Use this when your parser cannot decode into map[string]any and
+// you need to supply a hand-written KeyTree for set-by-config detection.
 //
-// The extension should include the dot (e.g., ".yaml", ".toml").
+// The extension should include the dot (e.g., ".mycustom").
 //
-// Registration is not goroutine-safe; call from init() or from main-goroutine
-// startup before any commands run. Passing a ConfigFormat with a nil Unmarshal
-// panics — a missing parser is a programming error and is surfaced eagerly so
-// you don't silently fall through to the JSON handler at parse time.
+// Registration is goroutine-safe — the registry is guarded by a sync.RWMutex,
+// so you can register formats from any goroutine. In practice, calling from
+// init() or main-goroutine startup (before any commands run) is still the
+// clearest model.
+//
+// Passing a ConfigFormat with a nil Unmarshal panics — a missing parser is a
+// programming error and is surfaced eagerly so you don't silently fall
+// through to the JSON handler at parse time.
 //
 // Example (using gopkg.in/yaml.v3):
 //
@@ -658,16 +674,27 @@ func RegisterConfigFormatFull(ext string, format ConfigFormat) {
 	if format.Unmarshal == nil {
 		panic(fmt.Errorf("boa: RegisterConfigFormatFull(%q): ConfigFormat.Unmarshal must be non-nil", ext))
 	}
+	configFormatsMu.Lock()
+	defer configFormatsMu.Unlock()
 	configFormats[ext] = format
 }
 
-// ConfigFormatExtensions returns the file extensions that have registered config format handlers.
-// Always includes ".json" (registered by default). Additional formats are added via RegisterConfigFormat.
+// ConfigFormatExtensions returns the file extensions that have registered
+// config format handlers, sorted alphabetically for deterministic iteration.
+// Always includes ".json" (registered by default). Additional formats are
+// added via RegisterConfigFormat or RegisterConfigFormatFull.
+//
+// The sort matters for callers like boaviper.FindConfig that probe the same
+// search path with every registered extension: without a stable order, which
+// file wins is nondeterministic when two extensions' files both exist.
 func ConfigFormatExtensions() []string {
+	configFormatsMu.RLock()
 	exts := make([]string, 0, len(configFormats))
 	for ext := range configFormats {
 		exts = append(exts, ext)
 	}
+	configFormatsMu.RUnlock()
+	sort.Strings(exts)
 	return exts
 }
 
@@ -702,7 +729,10 @@ func resolveConfigFormat(filePath string, override ConfigFormat) ConfigFormat {
 		return override
 	}
 	ext := filepath.Ext(filePath)
-	if cf, ok := configFormats[ext]; ok && cf.Unmarshal != nil {
+	configFormatsMu.RLock()
+	cf, ok := configFormats[ext]
+	configFormatsMu.RUnlock()
+	if ok && cf.Unmarshal != nil {
 		return cf
 	}
 	return ConfigFormat{Unmarshal: json.Unmarshal, KeyTree: jsonKeyTree}

--- a/pkg/boa/api_typed_base.go
+++ b/pkg/boa/api_typed_base.go
@@ -77,7 +77,16 @@ type CmdT[Struct any] struct {
 	ValidArgsFunc func(params *Struct, cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
 	// ConfigUnmarshal specifies the unmarshal function for config files loaded via the configfile tag.
 	// If nil, defaults to json.Unmarshal.
+	//
+	// For richer support (including key-presence probing that lets boa detect
+	// zero-valued or default-matching writes to optional struct-pointer groups),
+	// prefer the ConfigFormat field. When both are set, ConfigFormat wins.
 	ConfigUnmarshal func([]byte, any) error
+	// ConfigFormat specifies a per-command config file format — both the
+	// unmarshaler and an optional key-tree probe used for set-by-config detection.
+	// When set, this takes precedence over ConfigUnmarshal and over any format
+	// registered via RegisterConfigFormat for the file extension.
+	ConfigFormat ConfigFormat
 	// RawArgs allows injecting command line arguments instead of using os.Args
 	RawArgs []string
 }
@@ -223,6 +232,7 @@ func (b CmdT[Struct]) ToCmd() Cmd {
 		PreValidateFuncCtx: preValidateFuncCtx,
 		PreExecuteFuncCtx:  preExecuteFuncCtx,
 		ConfigUnmarshal:    b.ConfigUnmarshal,
+		ConfigFormat:       b.ConfigFormat,
 		RawArgs:            b.RawArgs,
 	}
 }

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -33,11 +34,18 @@ func fakeKeyTree(data []byte) (map[string]any, error) {
 // previous registry entry (if any) on test completion. Snapshot + restore
 // keeps the suite hermetic even when a test overrides a built-in or
 // previously-registered format — a blind delete would silently drop those.
+//
+// All direct mutations of configFormats go through configFormatsMu so the
+// race detector stays happy alongside concurrent test runs.
 func registerFormatCleanup(t *testing.T, ext string, f ConfigFormat) {
 	t.Helper()
+	configFormatsMu.RLock()
 	prev, hadPrev := configFormats[ext]
+	configFormatsMu.RUnlock()
 	RegisterConfigFormatFull(ext, f)
 	t.Cleanup(func() {
+		configFormatsMu.Lock()
+		defer configFormatsMu.Unlock()
 		if hadPrev {
 			configFormats[ext] = prev
 			return
@@ -147,6 +155,126 @@ func registerSimpleFormatCleanup(t *testing.T, ext string, fn func([]byte, any) 
 		}
 		delete(configFormats, ext)
 	})
+}
+
+// TestConfigFormatExtensions_Sorted proves ConfigFormatExtensions returns a
+// stable sorted slice, not randomized map iteration order. boaviper's
+// FindConfig relies on a deterministic probe order when the same search path
+// could match several registered extensions; without the sort, which file
+// wins would depend on goroutine state.
+func TestConfigFormatExtensions_Sorted(t *testing.T) {
+	registerFormatCleanup(t, ".bbb", ConfigFormat{Unmarshal: fakeUnmarshal})
+	registerFormatCleanup(t, ".aaa", ConfigFormat{Unmarshal: fakeUnmarshal})
+	registerFormatCleanup(t, ".zzz", ConfigFormat{Unmarshal: fakeUnmarshal})
+
+	exts := ConfigFormatExtensions()
+	if !sort.StringsAreSorted(exts) {
+		t.Fatalf("ConfigFormatExtensions should return sorted slice, got %v", exts)
+	}
+	// Quick sanity: all three test extensions must be present and .json too.
+	seen := map[string]bool{}
+	for _, e := range exts {
+		seen[e] = true
+	}
+	for _, want := range []string{".aaa", ".bbb", ".zzz", ".json"} {
+		if !seen[want] {
+			t.Errorf("expected %q in extensions, got %v", want, exts)
+		}
+	}
+}
+
+// TestSnapshotFallbackIsScopedPerLoad reproduces the bug CodeRabbit flagged:
+// a sub-load whose format lacks a KeyTree used to trigger a whole-tree
+// snapshot fallback, which over-marked fields in *other* subtrees whose
+// root-level KeyTree load had already covered them precisely.
+//
+// Setup:
+//
+//   - Root config (.json, built-in KeyTree): writes DB.Host to a non-default
+//     value. Precise KeyTree detection should mark DB.Host as set-by-config
+//     and leave DB.Port alone.
+//   - Substruct config (.nokt, no KeyTree): forces a fallback that, with the
+//     old whole-tree behaviour, would blanket-mark everything inside the DB
+//     pointer group — including DB.Port — because snapshot comparison sees
+//     DB changed from the root's write.
+//
+// With the per-subtree scoping fix, the fallback is limited to the substruct's
+// own subtree, so DB.Port correctly reports HasValue=false.
+func TestSnapshotFallbackIsScopedPerLoad(t *testing.T) {
+	// .nokt: valid unmarshal, but deliberately no KeyTree → forces fallback.
+	registerFormatCleanup(t, ".nokt", ConfigFormat{Unmarshal: fakeUnmarshal})
+
+	type DB struct {
+		Host string `descr:"db host" default:"localhost"`
+		Port int    `descr:"db port" default:"5432"`
+	}
+	type SubCfg struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Note       string `descr:"sub note" default:"defaultnote"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *DB
+		Sub        SubCfg
+	}
+
+	dir := t.TempDir()
+
+	// Root config writes DB.Host to a non-default value. KeyTree works.
+	rootPath := filepath.Join(dir, "root.json")
+	if err := os.WriteFile(rootPath, []byte(`{"DB":{"Host":"rootval"}}`), 0o644); err != nil {
+		t.Fatalf("write root cfg: %v", err)
+	}
+
+	// Sub config uses the .nokt format (no KeyTree). Writes Sub.Note to a
+	// non-default value so the sub load actually does something.
+	subPath := filepath.Join(dir, "sub.nokt")
+	if err := os.WriteFile(subPath, []byte(`{"Note":"fromsub"}`), 0o644); err != nil {
+		t.Fatalf("write sub cfg: %v", err)
+	}
+
+	// Check setByConfig directly (we're in-package) instead of HasValue(),
+	// because HasValue() also returns true when a parameter has a default,
+	// which would confound this test — both DB.Host and DB.Port have
+	// defaults, so only the setByConfig flag distinguishes "the config
+	// file wrote this" from "the parameter has a default".
+	var gotDB *DB
+	var hostSetByConfig, portSetByConfig bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB == nil {
+				return
+			}
+			if pm, ok := ctx.GetParam(&p.DB.Host).(*paramMeta); ok {
+				hostSetByConfig = pm.setByConfig
+			}
+			if pm, ok := ctx.GetParam(&p.DB.Port).(*paramMeta); ok {
+				portSetByConfig = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", rootPath, "--sub-config-file", subPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDB == nil {
+		t.Fatal("expected DB pointer group to survive (root KeyTree marked Host)")
+	}
+	if gotDB.Host != "rootval" {
+		t.Errorf("DB.Host = %q, want rootval", gotDB.Host)
+	}
+	if !hostSetByConfig {
+		t.Error("DB.Host setByConfig should be true (root KeyTree marked it precisely)")
+	}
+	// The headline assertion: without per-subtree scoping, the sub-load's
+	// fallback would over-mark DB.Port here. With the fix, DB.Port is
+	// correctly reported as NOT set by config.
+	if portSetByConfig {
+		t.Error("DB.Port setByConfig should be false — the sub-load's snapshot fallback must not leak into the DB subtree covered by the root KeyTree")
+	}
 }
 
 func TestRegisterConfigFormatFull_NilUnmarshalPanics(t *testing.T) {

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -277,6 +277,112 @@ func TestSnapshotFallbackIsScopedPerLoad(t *testing.T) {
 	}
 }
 
+// TestRegisterConfigFormatFull_NormalizesDotlessExtension covers the DX
+// that a forgotten leading dot doesn't silently break dispatch. Both "yaml"
+// and ".yaml" forms end up at the same canonical key, and a load of
+// config.yaml actually reaches the registered handler (instead of falling
+// through to JSON).
+func TestRegisterConfigFormatFull_NormalizesDotlessExtension(t *testing.T) {
+	// A sentinel Unmarshal that records whether it was called.
+	var called bool
+	sentinel := func(data []byte, target any) error {
+		called = true
+		return fakeUnmarshal(data, target)
+	}
+
+	// Register WITHOUT a leading dot.
+	registerFormatCleanup(t, "fmtNoDot", UniversalConfigFormat(sentinel))
+
+	// The canonical key in the registry should be ".fmtNoDot".
+	configFormatsMu.RLock()
+	_, canonicalOK := configFormats[".fmtNoDot"]
+	_, rawOK := configFormats["fmtNoDot"]
+	configFormatsMu.RUnlock()
+	if !canonicalOK {
+		t.Error("registration should normalize 'fmtNoDot' to '.fmtNoDot' in the registry")
+	}
+	if rawOK {
+		t.Error("the dot-less form should not appear as a separate registry key")
+	}
+
+	// ConfigFormatExtensions should report the canonical form only.
+	exts := ConfigFormatExtensions()
+	var sawCanonical, sawRaw bool
+	for _, e := range exts {
+		if e == ".fmtNoDot" {
+			sawCanonical = true
+		}
+		if e == "fmtNoDot" {
+			sawRaw = true
+		}
+	}
+	if !sawCanonical {
+		t.Error("ConfigFormatExtensions should list the canonical '.fmtNoDot'")
+	}
+	if sawRaw {
+		t.Error("ConfigFormatExtensions should not list the dot-less 'fmtNoDot' (would break boaviper's path construction)")
+	}
+
+	// Most important: actually loading a file through the normalized
+	// registration path should hit the sentinel unmarshaler. Before this
+	// fix, registering with "fmtNoDot" left the handler unreachable.
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Host       string `optional:"true"`
+	}
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtNoDot")
+	if err := os.WriteFile(cfgPath, []byte(`{"Host":"x"}`), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+	var gotHost string
+	if err := (CmdT[Params]{
+		Use: "test",
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !called {
+		t.Error("sentinel Unmarshal should have been invoked via normalized registry key")
+	}
+	if gotHost != "x" {
+		t.Errorf("Host = %q, want x", gotHost)
+	}
+}
+
+// TestRegisterConfigFormatFull_DottedExtensionUnchanged confirms that the
+// already-dotted form still works (no double-dot normalization bug).
+func TestRegisterConfigFormatFull_DottedExtensionUnchanged(t *testing.T) {
+	registerFormatCleanup(t, ".fmtDotted", UniversalConfigFormat(fakeUnmarshal))
+	configFormatsMu.RLock()
+	_, hasDotted := configFormats[".fmtDotted"]
+	_, hasDoubleDot := configFormats["..fmtDotted"]
+	configFormatsMu.RUnlock()
+	if !hasDotted {
+		t.Error("already-dotted form should be stored under '.fmtDotted'")
+	}
+	if hasDoubleDot {
+		t.Error("normalization should not prepend a second dot when one is already present")
+	}
+}
+
+// TestRegisterConfigFormatFull_EmptyExtPanics is the one case we still reject:
+// an outright empty string is unambiguously a programming mistake.
+func TestRegisterConfigFormatFull_EmptyExtPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected RegisterConfigFormatFull('') to panic")
+		}
+		if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "empty") {
+			t.Errorf("panic message should mention emptiness; got: %s", msg)
+		}
+	}()
+	RegisterConfigFormatFull("", ConfigFormat{Unmarshal: fakeUnmarshal})
+}
+
 func TestRegisterConfigFormatFull_NilUnmarshalPanics(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -28,8 +29,35 @@ func fakeKeyTree(data []byte) (map[string]any, error) {
 	return out, nil
 }
 
+// registerFormatCleanup registers a format and schedules its removal from the
+// global registry on test completion, so globally-scoped state doesn't leak
+// across tests within the same run.
+func registerFormatCleanup(t *testing.T, ext string, f ConfigFormat) {
+	t.Helper()
+	RegisterConfigFormatFull(ext, f)
+	t.Cleanup(func() { delete(configFormats, ext) })
+}
+
+func TestRegisterConfigFormatFull_NilUnmarshalPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected RegisterConfigFormatFull to panic when Unmarshal is nil")
+		}
+		// Also assert the panic message mentions the extension so users can
+		// trace the source without a stack walk.
+		if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, ".fmtBroken") {
+			t.Errorf("panic message should mention the bad extension; got: %s", msg)
+		}
+	}()
+	RegisterConfigFormatFull(".fmtBroken", ConfigFormat{
+		// Unmarshal deliberately left nil — a user who forgot to wire it up.
+		KeyTree: fakeKeyTree,
+	})
+}
+
 func TestCustomConfigFormat_KeyTreeDetectsZeroValueWrite(t *testing.T) {
-	RegisterConfigFormatFull(".fmtA", ConfigFormat{
+	registerFormatCleanup(t, ".fmtA", ConfigFormat{
 		Unmarshal: fakeUnmarshal,
 		KeyTree:   fakeKeyTree,
 	})
@@ -82,6 +110,7 @@ func TestCustomConfigFormat_RegisteredFormatAppliesToCmd(t *testing.T) {
 	// the command still runs successfully (format resolution by extension,
 	// graceful snapshot fallback for key-presence detection).
 	RegisterConfigFormat(".fmtB", fakeUnmarshal)
+	t.Cleanup(func() { delete(configFormats, ".fmtB") })
 
 	type Params struct {
 		ConfigFile string `configfile:"true" optional:"true"`
@@ -113,7 +142,7 @@ func TestCustomConfigFormat_RegisteredFormatAppliesToCmd(t *testing.T) {
 func TestCustomConfigFormat_CmdConfigFormatOverridesExtension(t *testing.T) {
 	// Register an extension-level handler that would mangle the data, then
 	// use Cmd.ConfigFormat to override it per-command. The override must win.
-	RegisterConfigFormatFull(".fmtC", ConfigFormat{
+	registerFormatCleanup(t, ".fmtC", ConfigFormat{
 		Unmarshal: func(data []byte, target any) error {
 			return fmt.Errorf("extension handler should not be called when Cmd.ConfigFormat is set")
 		},
@@ -162,7 +191,7 @@ func TestCustomConfigFormat_CmdConfigFormatOverridesExtension(t *testing.T) {
 // --config-file extension — with no per-command override and no code changes
 // between deployments.
 func TestCustomConfigFormat_MultipleFormatsOneBinary(t *testing.T) {
-	RegisterConfigFormatFull(".fmtMulti", ConfigFormat{
+	registerFormatCleanup(t, ".fmtMulti", ConfigFormat{
 		Unmarshal: fakeUnmarshal,
 		KeyTree:   fakeKeyTree,
 	})
@@ -235,7 +264,7 @@ func TestCustomConfigFormat_MultipleFormatsOneBinary(t *testing.T) {
 // the parameter's default, so only a working KeyTree-based detector can keep
 // the pointer chain alive after cleanup.
 func TestCustomConfigFormat_DeepNestingUnderCustomFormat(t *testing.T) {
-	RegisterConfigFormatFull(".fmtDeep", ConfigFormat{
+	registerFormatCleanup(t, ".fmtDeep", ConfigFormat{
 		Unmarshal: fakeUnmarshal,
 		KeyTree:   fakeKeyTree,
 	})
@@ -329,7 +358,7 @@ func TestCustomConfigFormat_DeepNestingUnderCustomFormat(t *testing.T) {
 func TestCustomConfigFormat_KeyTreeHandlesMapAnyAny(t *testing.T) {
 	// yaml.v2 and some other parsers produce map[any]any for nested mappings.
 	// The walker's asKeyMap helper must coerce these transparently.
-	RegisterConfigFormatFull(".fmtD", ConfigFormat{
+	registerFormatCleanup(t, ".fmtD", ConfigFormat{
 		Unmarshal: fakeUnmarshal,
 		KeyTree: func(data []byte) (map[string]any, error) {
 			// Mimic yaml.v2: nested mappings come back as map[any]any.

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -1,0 +1,207 @@
+package boa
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// fakeUnmarshal delegates to encoding/json so we can reuse JSON bytes on disk
+// while still exercising the ConfigFormat plumbing under a non-".json"
+// extension — this proves the extension lookup path is wired correctly.
+func fakeUnmarshal(data []byte, target any) error {
+	return json.Unmarshal(data, target)
+}
+
+// fakeKeyTree builds the KeyTree as a plain map[string]any. Matching the
+// jsonKeyTree shape ensures the generic walker in markConfigKeysPresentInStruct
+// is format-agnostic.
+func fakeKeyTree(data []byte) (map[string]any, error) {
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func TestCustomConfigFormat_KeyTreeDetectsZeroValueWrite(t *testing.T) {
+	RegisterConfigFormatFull(".fmtA", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree:   fakeKeyTree,
+	})
+
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// Write Host="" (zero value) AND Port=5432 (same as default).
+	// Snapshot comparison alone cannot distinguish these from "never set",
+	// so this is the acid test for KeyTree-based detection.
+	raw := []byte(`{"DB":{"Host":"","Port":5432}}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtA")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotDB *Inner
+	var dbSetByConfig bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				dbSetByConfig = ctx.HasValue(&p.DB.Host) && ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDB == nil {
+		t.Fatal("expected DB pointer group to survive cleanup (zero-value + default writes should be detected via KeyTree)")
+	}
+	if !dbSetByConfig {
+		t.Error("expected both Host and Port to report HasValue=true after KeyTree-based detection")
+	}
+}
+
+func TestCustomConfigFormat_RegisteredFormatAppliesToCmd(t *testing.T) {
+	// Use a dedicated extension with only Unmarshal — no KeyTree — and verify
+	// the command still runs successfully (format resolution by extension,
+	// graceful snapshot fallback for key-presence detection).
+	RegisterConfigFormat(".fmtB", fakeUnmarshal)
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Host       string `optional:"true"`
+	}
+
+	raw := []byte(`{"Host":"from-fmtB"}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtB")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotHost string
+	err := (CmdT[Params]{
+		Use: "test",
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "from-fmtB" {
+		t.Errorf("expected Host=from-fmtB, got %q", gotHost)
+	}
+}
+
+func TestCustomConfigFormat_CmdConfigFormatOverridesExtension(t *testing.T) {
+	// Register an extension-level handler that would mangle the data, then
+	// use Cmd.ConfigFormat to override it per-command. The override must win.
+	RegisterConfigFormatFull(".fmtC", ConfigFormat{
+		Unmarshal: func(data []byte, target any) error {
+			return fmt.Errorf("extension handler should not be called when Cmd.ConfigFormat is set")
+		},
+	})
+
+	type Inner struct {
+		Host string `descr:"host"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	raw := []byte(`{"DB":{"Host":""}}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtC")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		ConfigFormat: ConfigFormat{
+			Unmarshal: fakeUnmarshal,
+			KeyTree:   fakeKeyTree,
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The per-command override provides a KeyTree, so DB must survive cleanup
+	// even though its only written field is the zero value.
+	if gotDB == nil {
+		t.Fatal("expected DB pointer group to be non-nil when Cmd.ConfigFormat with KeyTree is used")
+	}
+}
+
+func TestCustomConfigFormat_KeyTreeHandlesMapAnyAny(t *testing.T) {
+	// yaml.v2 and some other parsers produce map[any]any for nested mappings.
+	// The walker's asKeyMap helper must coerce these transparently.
+	RegisterConfigFormatFull(".fmtD", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree: func(data []byte) (map[string]any, error) {
+			// Mimic yaml.v2: nested mappings come back as map[any]any.
+			return map[string]any{
+				"DB": map[any]any{
+					"Host": "",
+					"Port": 5432,
+				},
+			}, nil
+		},
+	})
+
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	// Bytes are JSON-parseable so fakeUnmarshal can populate the struct; the
+	// KeyTree deliberately returns map[any]any to exercise coercion.
+	raw := []byte(`{"DB":{"Host":"","Port":5432}}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtD")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotDB *Inner
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("expected DB pointer group to survive when KeyTree returns map[any]any for nested mappings")
+	}
+}

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -29,13 +29,21 @@ func fakeKeyTree(data []byte) (map[string]any, error) {
 	return out, nil
 }
 
-// registerFormatCleanup registers a format and schedules its removal from the
-// global registry on test completion, so globally-scoped state doesn't leak
-// across tests within the same run.
+// registerFormatCleanup registers a format and schedules restoration of the
+// previous registry entry (if any) on test completion. Snapshot + restore
+// keeps the suite hermetic even when a test overrides a built-in or
+// previously-registered format — a blind delete would silently drop those.
 func registerFormatCleanup(t *testing.T, ext string, f ConfigFormat) {
 	t.Helper()
+	prev, hadPrev := configFormats[ext]
 	RegisterConfigFormatFull(ext, f)
-	t.Cleanup(func() { delete(configFormats, ext) })
+	t.Cleanup(func() {
+		if hadPrev {
+			configFormats[ext] = prev
+			return
+		}
+		delete(configFormats, ext)
+	})
 }
 
 func TestRegisterConfigFormatFull_NilUnmarshalPanics(t *testing.T) {
@@ -109,8 +117,7 @@ func TestCustomConfigFormat_RegisteredFormatAppliesToCmd(t *testing.T) {
 	// Use a dedicated extension with only Unmarshal — no KeyTree — and verify
 	// the command still runs successfully (format resolution by extension,
 	// graceful snapshot fallback for key-presence detection).
-	RegisterConfigFormat(".fmtB", fakeUnmarshal)
-	t.Cleanup(func() { delete(configFormats, ".fmtB") })
+	registerFormatCleanup(t, ".fmtB", ConfigFormat{Unmarshal: fakeUnmarshal})
 
 	type Params struct {
 		ConfigFile string `configfile:"true" optional:"true"`

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -228,6 +228,104 @@ func TestCustomConfigFormat_MultipleFormatsOneBinary(t *testing.T) {
 	}
 }
 
+// TestCustomConfigFormat_DeepNestingUnderCustomFormat proves that the KeyTree
+// walker is format-agnostic and descends arbitrarily deep. Three levels of
+// optional struct-pointer groups, plus a non-pointer substruct in the middle
+// for good measure — every leaf value is written as either the zero value or
+// the parameter's default, so only a working KeyTree-based detector can keep
+// the pointer chain alive after cleanup.
+func TestCustomConfigFormat_DeepNestingUnderCustomFormat(t *testing.T) {
+	RegisterConfigFormatFull(".fmtDeep", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree:   fakeKeyTree,
+	})
+
+	type Leaf struct {
+		Host string `descr:"leaf host" default:"localhost"`
+		Port int    `descr:"leaf port" default:"5432"`
+	}
+	type Middle struct {
+		// Non-pointer substruct inside a pointer group.
+		Region string `descr:"middle region" default:"us-east-1"`
+		Deepest *Leaf
+	}
+	type Top struct {
+		Name   string `descr:"top name" default:"primary"`
+		Middle *Middle
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Top        *Top
+	}
+
+	// Every written value either equals the zero value or equals the default.
+	// Snapshot comparison alone would say "nothing changed" and nil all three
+	// pointers out during cleanup.
+	raw := []byte(`{
+		"Top": {
+			"Name": "primary",
+			"Middle": {
+				"Region": "us-east-1",
+				"Deepest": {
+					"Host": "",
+					"Port": 5432
+				}
+			}
+		}
+	}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "deep.fmtDeep")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotTop *Top
+	var deepestHostSet, deepestPortSet bool
+	var middleRegionSet, topNameSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotTop = p.Top
+			if p.Top != nil {
+				topNameSet = ctx.HasValue(&p.Top.Name)
+				if p.Top.Middle != nil {
+					middleRegionSet = ctx.HasValue(&p.Top.Middle.Region)
+					if p.Top.Middle.Deepest != nil {
+						deepestHostSet = ctx.HasValue(&p.Top.Middle.Deepest.Host)
+						deepestPortSet = ctx.HasValue(&p.Top.Middle.Deepest.Port)
+					}
+				}
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotTop == nil {
+		t.Fatal("expected Top pointer group to survive cleanup (level 1)")
+	}
+	if gotTop.Middle == nil {
+		t.Fatal("expected Top.Middle pointer group to survive cleanup (level 2)")
+	}
+	if gotTop.Middle.Deepest == nil {
+		t.Fatal("expected Top.Middle.Deepest pointer group to survive cleanup (level 3)")
+	}
+	if !topNameSet {
+		t.Error("level 1 leaf: expected Top.Name to report HasValue=true (same-as-default write)")
+	}
+	if !middleRegionSet {
+		t.Error("level 2 leaf (inside pointer group): expected Top.Middle.Region to report HasValue=true")
+	}
+	if !deepestHostSet {
+		t.Error("level 3 leaf (pointer inside pointer): expected Top.Middle.Deepest.Host to report HasValue=true (zero-value write)")
+	}
+	if !deepestPortSet {
+		t.Error("level 3 leaf (pointer inside pointer): expected Top.Middle.Deepest.Port to report HasValue=true (same-as-default write)")
+	}
+}
+
 func TestCustomConfigFormat_KeyTreeHandlesMapAnyAny(t *testing.T) {
 	// yaml.v2 and some other parsers produce map[any]any for nested mappings.
 	// The walker's asKeyMap helper must coerce these transparently.

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -46,6 +46,109 @@ func registerFormatCleanup(t *testing.T, ext string, f ConfigFormat) {
 	})
 }
 
+// TestUniversalConfigFormat_SynthesizesKeyTree proves that the one-liner
+// helper produces a ConfigFormat whose KeyTree decodes via the same unmarshal
+// function — no closure required from the caller.
+func TestUniversalConfigFormat_SynthesizesKeyTree(t *testing.T) {
+	cf := UniversalConfigFormat(fakeUnmarshal)
+	if cf.Unmarshal == nil {
+		t.Fatal("Unmarshal should be non-nil")
+	}
+	if cf.KeyTree == nil {
+		t.Fatal("KeyTree should be auto-synthesized")
+	}
+	tree, err := cf.KeyTree([]byte(`{"DB":{"Host":"","Port":5432}}`))
+	if err != nil {
+		t.Fatalf("KeyTree returned error: %v", err)
+	}
+	db, ok := tree["DB"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected DB to be map[string]any, got %T", tree["DB"])
+	}
+	if _, ok := db["Host"]; !ok {
+		t.Error("expected DB.Host key in synthesized tree")
+	}
+	if _, ok := db["Port"]; !ok {
+		t.Error("expected DB.Port key in synthesized tree")
+	}
+}
+
+func TestUniversalConfigFormat_NilUnmarshalPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected UniversalConfigFormat(nil) to panic")
+		}
+		if msg := fmt.Sprintf("%v", r); !strings.Contains(msg, "UniversalConfigFormat") {
+			t.Errorf("panic message should mention the helper name; got: %s", msg)
+		}
+	}()
+	UniversalConfigFormat(nil)
+}
+
+// TestRegisterConfigFormat_SimpleFormGivesFullDetection covers the headline
+// DX improvement: a plain RegisterConfigFormat(ext, fn) call — no closure,
+// no ConfigFormat literal — should give the same zero-value and
+// same-as-default detection that previously required the verbose full form.
+func TestRegisterConfigFormat_SimpleFormGivesFullDetection(t *testing.T) {
+	registerSimpleFormatCleanup(t, ".fmtSimple", fakeUnmarshal)
+
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	raw := []byte(`{"DB":{"Host":"","Port":5432}}`)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.fmtSimple")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var gotDB *Inner
+	var dbBothSetViaCfg bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				dbBothSetViaCfg = ctx.HasValue(&p.DB.Host) && ctx.HasValue(&p.DB.Port)
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotDB == nil {
+		t.Fatal("expected DB pointer group to survive cleanup under simple RegisterConfigFormat call (KeyTree should be auto-synthesized)")
+	}
+	if !dbBothSetViaCfg {
+		t.Error("expected both DB.Host and DB.Port to report HasValue=true via auto-synthesized KeyTree")
+	}
+}
+
+// registerSimpleFormatCleanup is the simple-form counterpart to
+// registerFormatCleanup: it routes through RegisterConfigFormat (not
+// ...Full) and still restores any prior registry entry on test completion.
+func registerSimpleFormatCleanup(t *testing.T, ext string, fn func([]byte, any) error) {
+	t.Helper()
+	prev, hadPrev := configFormats[ext]
+	RegisterConfigFormat(ext, fn)
+	t.Cleanup(func() {
+		if hadPrev {
+			configFormats[ext] = prev
+			return
+		}
+		delete(configFormats, ext)
+	})
+}
+
 func TestRegisterConfigFormatFull_NilUnmarshalPanics(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -156,6 +156,78 @@ func TestCustomConfigFormat_CmdConfigFormatOverridesExtension(t *testing.T) {
 	}
 }
 
+// TestCustomConfigFormat_MultipleFormatsOneBinary covers the headline scenario:
+// a single compiled program registers a non-JSON format at init/startup and
+// is then able to load EITHER a .json or a .fmtMulti file — picked per-run by
+// --config-file extension — with no per-command override and no code changes
+// between deployments.
+func TestCustomConfigFormat_MultipleFormatsOneBinary(t *testing.T) {
+	RegisterConfigFormatFull(".fmtMulti", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree:   fakeKeyTree,
+	})
+
+	type Inner struct {
+		Host string `descr:"host" default:"localhost"`
+		Port int    `descr:"port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *Inner
+	}
+
+	newCmd := func(captured **Inner, ctxCapture *bool, _ **HookContext) CmdT[Params] {
+		return CmdT[Params]{
+			Use:         "test",
+			ParamEnrich: ParamEnricherName,
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				*captured = p.DB
+				if p.DB != nil {
+					*ctxCapture = ctx.HasValue(&p.DB.Host) && ctx.HasValue(&p.DB.Port)
+				}
+			},
+		}
+	}
+
+	dir := t.TempDir()
+
+	// Pass 1: load a .json file. Uses the built-in JSON handler, including its KeyTree.
+	jsonPath := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"DB":{"Host":"","Port":5432}}`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	var gotDB *Inner
+	var ctxHasBoth bool
+	if err := newCmd(&gotDB, &ctxHasBoth, nil).RunArgsE([]string{"--config-file", jsonPath}); err != nil {
+		t.Fatalf("json run: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("json run: expected DB pointer group to survive (KeyTree detects zero-value + default writes)")
+	}
+	if !ctxHasBoth {
+		t.Error("json run: expected both DB.Host and DB.Port to report HasValue=true")
+	}
+
+	// Pass 2: SAME command struct, same process, different file extension.
+	// Dispatch goes through the registered .fmtMulti handler — no per-command
+	// override, no rebuild, just a different --config-file argument.
+	altPath := filepath.Join(dir, "cfg.fmtMulti")
+	if err := os.WriteFile(altPath, []byte(`{"DB":{"Host":"","Port":5432}}`), 0o644); err != nil {
+		t.Fatalf("write alt: %v", err)
+	}
+	gotDB = nil
+	ctxHasBoth = false
+	if err := newCmd(&gotDB, &ctxHasBoth, nil).RunArgsE([]string{"--config-file", altPath}); err != nil {
+		t.Fatalf("alt run: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("alt run: expected DB pointer group to survive under registered custom format")
+	}
+	if !ctxHasBoth {
+		t.Error("alt run: expected both DB.Host and DB.Port to report HasValue=true via custom KeyTree")
+	}
+}
+
 func TestCustomConfigFormat_KeyTreeHandlesMapAnyAny(t *testing.T) {
 	// yaml.v2 and some other parsers produce map[any]any for nested mappings.
 	// The walker's asKeyMap helper must coerce these transparently.

--- a/pkg/boa/coverage_test.go
+++ b/pkg/boa/coverage_test.go
@@ -1870,7 +1870,7 @@ func TestLoadConfigFileExtensionLookup(t *testing.T) {
 	_ = tmpFile.Close()
 
 	var cfg Config
-	_, err := loadConfigFileInto(tmpFile.Name(), &cfg, nil)
+	_, _, err := loadConfigFileInto(tmpFile.Name(), &cfg, ConfigFormat{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -513,10 +513,26 @@ func snapshotPreallocatedStructs(ctx *processingContext) []reflect.Value {
 
 // markConfigChangedStructs compares preallocated struct values against pre-config
 // snapshots. If any struct changed, marks all its mirrors as setByConfig.
-// This is the fallback for non-JSON formats where key-presence detection can't work.
-func markConfigChangedStructs(ctx *processingContext, snapshots []reflect.Value) {
+// This is the fallback for formats whose KeyTree cannot describe the literal
+// key structure (no KeyTree set, or the KeyTree returned an error).
+//
+// The fallback is scoped per-load via fallbackRoots: a preallocated pointer
+// is only considered if its path lies within one of those subtrees. This
+// prevents a failing sub-load from blanket-marking fields that a *separate*
+// load already covered precisely via its own KeyTree. An empty fieldPath in
+// the list means "the entire root" (the legacy whole-tree behaviour, used
+// when the root config itself has no KeyTree).
+//
+// An empty fallbackRoots slice is a no-op.
+func markConfigChangedStructs(ctx *processingContext, snapshots []reflect.Value, fallbackRoots []fieldPath) {
+	if len(fallbackRoots) == 0 {
+		return
+	}
 	for i, info := range ctx.PreallocatedPtrs {
 		if info.ptrField.IsNil() || !snapshots[i].IsValid() {
+			continue
+		}
+		if !pathWithinAny(info.path, fallbackRoots) {
 			continue
 		}
 		current := info.ptrField.Elem()
@@ -524,6 +540,13 @@ func markConfigChangedStructs(ctx *processingContext, snapshots []reflect.Value)
 			markAllMirrorsInSubtree(ctx, info.ptrField.Interface(), splitPath(info.path))
 		}
 	}
+}
+
+// pathWithinAny reports whether child lies within (or equals) any of roots.
+// Uses fieldPath.hasSubtreePrefix so segment boundaries are respected (i.e.,
+// path "12" is NOT considered within root "1"; only "1", "1.X", "1.X.Y"... are).
+func pathWithinAny(child fieldPath, roots []fieldPath) bool {
+	return slices.ContainsFunc(roots, child.hasSubtreePrefix)
 }
 
 // markStructPtrPresentByConfig records that a preallocated struct pointer was
@@ -1881,18 +1904,18 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// Probe raw config data for key presence to detect which preallocated
 			// struct pointers were mentioned in config files. This detects writes
 			// even when the value equals Go's zero value or the field's default.
-			// Formats whose ConfigFormat has no KeyTree fall back to snapshot comparison.
-			allDetected := true
+			// Formats whose ConfigFormat has no KeyTree (or whose KeyTree errors
+			// out) fall back to snapshot comparison — but only for the subtree
+			// of that particular load, so a failing sub-load can't corrupt the
+			// precision of sibling loads whose KeyTree succeeded.
+			var fallbackRoots []fieldPath
 			for _, cr := range configResults {
 				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData, cr.format) {
-					allDetected = false
+					fallbackRoots = append(fallbackRoots, cr.targetPath)
 				}
 			}
-			if !allDetected && preConfigSnapshots != nil {
-				// Non-JSON config format: fall back to comparing struct values
-				// before and after config loading. This catches changed values
-				// but can't detect zero-value or same-as-default writes.
-				markConfigChangedStructs(ctx, preConfigSnapshots)
+			if len(fallbackRoots) > 0 && preConfigSnapshots != nil {
+				markConfigChangedStructs(ctx, preConfigSnapshots, fallbackRoots)
 			}
 
 			// Clean up preallocated struct pointers that had no fields set.

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -2,7 +2,6 @@ package boa
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -349,23 +348,26 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 // which preallocated struct pointer fields were explicitly mentioned in the config,
 // even if the values are zero or match the defaults.
 //
-// It unmarshals the raw bytes into map[string]json.RawMessage to get the set of
-// top-level keys, then matches them against struct field names using the same
-// case-insensitive logic as encoding/json. For nested structs, it recurses into
-// the sub-maps.
+// It delegates to the ConfigFormat's KeyTree to build a nested map[string]any
+// representing the raw bytes' key structure, then matches entries against
+// struct field names using case-insensitive logic (the same rule encoding/json
+// applies). For nested structs, it recurses into sub-maps.
 //
-// Returns true if key-presence detection succeeded (JSON-compatible data).
-// Returns false for non-JSON data so the caller can fall back to snapshot comparison.
-func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldPath, rawData []byte) bool {
+// Returns true if key-presence detection succeeded. Returns false when the
+// format has no KeyTree, when the probe errors out, or when there are no
+// preallocated pointer groups to care about — in those cases the caller
+// should fall back to snapshot comparison.
+func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldPath, rawData []byte, format ConfigFormat) bool {
 	if len(ctx.PreallocatedPtrs) == 0 || len(rawData) == 0 {
 		return false
 	}
-	// Probe the raw data for top-level keys
-	var topLevel map[string]json.RawMessage
-	if err := json.Unmarshal(rawData, &topLevel); err != nil {
-		return false // not JSON-compatible; caller should use snapshot fallback
+	if format.KeyTree == nil {
+		return false
 	}
-	// Walk the target struct type and match keys against preallocated struct ptrs
+	topLevel, err := format.KeyTree(rawData)
+	if err != nil || topLevel == nil {
+		return false
+	}
 	markConfigKeysPresentInStruct(ctx, target, topLevel, splitPath(targetPath))
 	return true
 }
@@ -410,9 +412,10 @@ func jsonFieldKey(field reflect.StructField) string {
 	return field.Name
 }
 
-// jsonKeyLookup does a case-insensitive key lookup matching encoding/json behavior:
-// exact match first, then case-insensitive fallback.
-func jsonKeyLookup(keys map[string]json.RawMessage, target string) (json.RawMessage, bool) {
+// configKeyLookup does a case-insensitive key lookup matching encoding/json behavior:
+// exact match first, then case-insensitive fallback. Works on any KeyTree output,
+// regardless of the underlying config format (JSON, YAML, TOML, …).
+func configKeyLookup(keys map[string]any, target string) (any, bool) {
 	if target == "" {
 		return nil, false
 	}
@@ -429,7 +432,26 @@ func jsonKeyLookup(keys map[string]json.RawMessage, target string) (json.RawMess
 	return nil, false
 }
 
-func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]json.RawMessage, path []int) {
+// asKeyMap coerces a KeyTree sub-value to a map[string]any when it is one,
+// tolerating the map[any]any shape that some YAML parsers (notably yaml.v2)
+// produce for nested mappings. Returns nil if the value is not a map-like.
+func asKeyMap(v any) map[string]any {
+	switch m := v.(type) {
+	case map[string]any:
+		return m
+	case map[any]any:
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			if ks, ok := k.(string); ok {
+				out[ks] = val
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]any, path []int) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
 	for i := 0; i < typ.NumField(); i++ {
@@ -438,8 +460,8 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 			continue
 		}
 		childPath := append(append([]int(nil), path...), i)
-		jsonKey := jsonFieldKey(field)
-		rawVal, keyPresent := jsonKeyLookup(keys, jsonKey)
+		key := jsonFieldKey(field)
+		rawVal, keyPresent := configKeyLookup(keys, key)
 		if !keyPresent {
 			continue
 		}
@@ -450,17 +472,15 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 			// pointer survives cleanup, even if the object is empty `{}`.
 			// Individual fields only get setByConfig if they appear as keys.
 			markStructPtrPresentByConfig(ctx, fieldVal.Interface())
-			var subKeys map[string]json.RawMessage
-			if json.Unmarshal(rawVal, &subKeys) == nil && len(subKeys) > 0 {
-				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subKeys, childPath)
+			if subMap := asKeyMap(rawVal); len(subMap) > 0 {
+				markConfigKeysPresentInStruct(ctx, fieldVal.Interface(), subMap, childPath)
 			}
 			continue
 		}
 		// If this is a non-pointer struct, recurse
 		if field.Type.Kind() == reflect.Struct && !isSupportedType(field.Type) {
-			var subKeys map[string]json.RawMessage
-			if json.Unmarshal(rawVal, &subKeys) == nil {
-				markConfigKeysPresentInStruct(ctx, fieldVal.Addr().Interface(), subKeys, childPath)
+			if subMap := asKeyMap(rawVal); subMap != nil {
+				markConfigKeysPresentInStruct(ctx, fieldVal.Addr().Interface(), subMap, childPath)
 			}
 			continue
 		}
@@ -1807,8 +1827,17 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				target     any
 				targetPath fieldPath
 				rawData    []byte
+				format     ConfigFormat
 			}
 			var configResults []configLoadResult
+
+			// Resolve the per-command override once. ConfigFormat takes
+			// precedence over the legacy ConfigUnmarshal; if neither is set,
+			// loadConfigFileInto falls back to the extension-registered format.
+			cmdOverride := b.ConfigFormat
+			if cmdOverride.Unmarshal == nil && b.ConfigUnmarshal != nil {
+				cmdOverride = ConfigFormat{Unmarshal: b.ConfigUnmarshal}
+			}
 
 			if len(ctx.ConfigFiles) > 0 {
 				// Separate root and substruct entries
@@ -1825,11 +1854,11 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 					if entry.mirror.HasValue() {
 						filePath := *(entry.mirror.valuePtrF().(*string))
 						if filePath != "" {
-							rawData, err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal)
+							rawData, effective, err := loadConfigFileInto(filePath, entry.target, cmdOverride)
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective})
 						}
 					}
 				}
@@ -1838,11 +1867,11 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 					if entry.mirror.HasValue() {
 						filePath := *(entry.mirror.valuePtrF().(*string))
 						if filePath != "" {
-							rawData, err := loadConfigFileInto(filePath, entry.target, b.ConfigUnmarshal)
+							rawData, effective, err := loadConfigFileInto(filePath, entry.target, cmdOverride)
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective})
 						}
 					}
 				}
@@ -1852,10 +1881,10 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// Probe raw config data for key presence to detect which preallocated
 			// struct pointers were mentioned in config files. This detects writes
 			// even when the value equals Go's zero value or the field's default.
-			// For non-JSON formats, fall back to snapshot comparison.
+			// Formats whose ConfigFormat has no KeyTree fall back to snapshot comparison.
 			allDetected := true
 			for _, cr := range configResults {
-				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData) {
+				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData, cr.format) {
 					allDetected = false
 				}
 			}


### PR DESCRIPTION
## Summary

Lets boa apps load YAML/TOML/HCL/… config files without forcing those parsers as hard dependencies, and fixes a latent gap where set-by-config detection for optional struct-pointer parameter groups was hard-locked to `encoding/json`.

Dispatch is **extension-driven**: the same compiled binary accepts any mix of registered formats at runtime (`--config-file prod.json` today, `--config-file prod.yaml` tomorrow, no rebuild). There is no per-command locking unless you explicitly ask for it.

## The one-liner

For every mainstream Go config parser, this is all you need:

```go
func init() {
    boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
    boa.RegisterConfigFormat(".toml", toml.Unmarshal)
}
```

One call gets you:

1. **Parsing** — the extension now dispatches to your library's unmarshal function.
2. **Full key-presence detection** — including zero-valued and same-as-default writes to optional struct-pointer parameter groups (`DB *DBConfig`).

Under the hood `RegisterConfigFormat` wraps the unmarshaler in a new `boa.UniversalConfigFormat`, which synthesizes the `KeyTree` probe by calling the same parser against a `map[string]any` target. Every mainstream Go parser supports that, so the `KeyTree` comes for free.

## API surface

```go
// The type describing a full format.
type ConfigFormat struct {
    Unmarshal func(data []byte, target any) error                 // required
    KeyTree   func(data []byte) (map[string]any, error)           // optional
}

// One-liner helper (panics on nil). RegisterConfigFormat uses it internally;
// call it directly when you want to attach a format inline to Cmd.ConfigFormat.
func UniversalConfigFormat(unmarshalFunc func([]byte, any) error) ConfigFormat

// Global registry, extension-keyed dispatch.
func RegisterConfigFormat(ext string, unmarshalFunc func([]byte, any) error)      // the one you'll use
func RegisterConfigFormatFull(ext string, format ConfigFormat)                    // advanced escape hatch

// Per-command overrides (bypass the registry for that one command).
type Cmd struct {
    // ...
    ConfigFormat   ConfigFormat                      // preferred
    ConfigUnmarshal func([]byte, any) error          // legacy, unmarshal-only
}
```

Resolution per `loadConfigFileInto` call:

1. `Cmd.ConfigFormat` (if `Unmarshal` is non-nil) — per-command escape hatch
2. `Cmd.ConfigUnmarshal` (legacy; unmarshal-only)
3. **Extension-registered format — the default path; any number of formats can coexist in one binary**
4. Built-in JSON fallback

## When to use the full form

`RegisterConfigFormatFull` + a hand-written `KeyTree` is only needed when your parser **cannot** decode into `map[string]any` — for example, a handwritten custom format whose unmarshaler only populates specific struct types. Third-party libraries (yaml.v3, BurntSushi/toml, hashicorp/hcl) all handle `map[string]any` natively, so they never need it.

The runnable example at `internal/example_custom_config_format` is exactly this edge case: a tiny dep-free "KV" format with a struct-only unmarshaler, registered via `RegisterConfigFormatFull` with a hand-written `kvKeyTree`. It exists to keep boa itself free of third-party parser deps while still proving the full-form path.

## Notes

- Built-in JSON handler now ships with its own `KeyTree` — behaviour for existing JSON users is unchanged.
- Legacy `Cmd.ConfigUnmarshal` still works; `Cmd.ConfigFormat` takes precedence when both are set.
- Registration panics on nil `Unmarshal` (`RegisterConfigFormatFull` and `UniversalConfigFormat` both fail fast instead of silently falling through to the JSON handler at parse time).
- Key-presence walker operates on `map[string]any` and coerces `map[any]any` (yaml.v2 shape) transparently via `asKeyMap`.
- Registration is not goroutine-safe — call from `init()` or main-goroutine startup.
- **No new `go.mod` entries.** `go.mod` / `go.sum` byte-for-byte unchanged.

## Docs

- `docs/examples-config.md`: leads with the one-liner; "Why key-presence detection matters" section explains the semantics with a YAML example; `UniversalConfigFormat` helper documented; full form demoted to an advanced escape hatch.
- `docs/advanced.md`, `docs/migration.md`, `CLAUDE.md`: synced to the same framing.
- `LoadConfigFile` godoc updated to describe the new extension-registry fallback order.

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `pkg/boa/config_format_test.go` covers:
  - `TestUniversalConfigFormat_SynthesizesKeyTree` — helper builds a working `KeyTree` from a plain unmarshaler.
  - `TestUniversalConfigFormat_NilUnmarshalPanics` — fail-fast on nil.
  - `TestRegisterConfigFormat_SimpleFormGivesFullDetection` — headline DX proof: plain `RegisterConfigFormat(ext, fn)` with no closure → DB pointer group survives cleanup, both leaves report `HasValue=true` on same-as-default writes.
  - `TestRegisterConfigFormatFull_NilUnmarshalPanics` — same fail-fast guarantee on the full form.
  - `TestCustomConfigFormat_KeyTreeDetectsZeroValueWrite` — full-form `KeyTree` detects zero-value + same-as-default writes.
  - `TestCustomConfigFormat_RegisteredFormatAppliesToCmd` — full form with no `KeyTree` still runs (snapshot fallback path).
  - `TestCustomConfigFormat_CmdConfigFormatOverridesExtension` — per-command `ConfigFormat` override beats extension registry.
  - `TestCustomConfigFormat_MultipleFormatsOneBinary` — same binary loads both `.json` and a registered custom format through the same command struct.
  - `TestCustomConfigFormat_DeepNestingUnderCustomFormat` — 3-level deep struct-pointer chain with a non-pointer substruct in the middle, every leaf written as zero-value / default, all four pointers survive and all four leaves report `HasValue=true` via the custom format's `KeyTree`.
  - `TestCustomConfigFormat_KeyTreeHandlesMapAnyAny` — `map[any]any` (yaml.v2 shape) coercion.
- [x] Runnable `internal/example_custom_config_format` with two tests (`TestCustomFormatRoundTrip`, `TestBuiltinJSONSameBinary`, `TestCustomFormatCLIOverride`) that drive the command via `RunArgsE` and assert on captured parse state — including that `--port 9999` actually overrides the config file value.
- [x] `go.mod` / `go.sum` byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for registering custom config file formats by extension (`.yaml`, `.toml`, etc.)
  * Implemented per-command config format override capability via `Cmd.ConfigFormat`
  * Enhanced detection of which config fields were explicitly set vs. using defaults for optional pointer groups
  * Config files of different formats can now be loaded by the same binary

<!-- end of auto-generated comment: release notes by coderabbit.ai -->