### PR TITLE
refactor: typed min/max storage, fix int64 precision above 2^53

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Every struct-tag feature has a matching method on `Param` / `ParamT[T]` so field
 - `SetNoFlag(bool)` / `IsNoFlag() bool` — mirrors `boa:"noflag"`
 - `SetNoEnv(bool)` / `IsNoEnv() bool` — mirrors `boa:"noenv"`
 - `SetIgnored(bool)` / `IsIgnored() bool` — post-traversal equivalent of `boa:"ignore"` (the tag itself skips traversal entirely, so the mirror never exists; the programmatic form marks an existing mirror as ignored so CLI/env/validation/sync are all skipped). For `boa:"configonly"`, call `SetNoFlag(true)` + `SetNoEnv(true)` instead.
-- `SetMin(float64)` / `ClearMin()` / `GetMin() *float64`, `SetMax(float64)` / `ClearMax()` / `GetMax() *float64`, `SetPattern(string)` / `GetPattern() string`
+- `SetMinT(T)` / `SetMaxT(T)` on `ParamT[T]` for numeric `T` (stores at full int64/float64 precision). `SetMinLen(int)` / `SetMaxLen(int)` for string / slice / map fields. `ClearMin()` / `ClearMax()` on both. The non-generic `Param` exposes `GetMin() any` / `SetMin(any)` / `ClearMin()` (same for Max), returning a typed pointer: `*int64` for signed ints, `*float64` for floats, `*int` for length-based fields. `SetPattern(string)` / `GetPattern() string` unchanged.
 - `SetDefault(any)` / typed `ParamT[T].SetDefaultT(T)`
 - `SetAlternatives([]string)`, `SetAlternativesFunc(...)`, `SetStrictAlts(bool)`
 - `SetCustomValidator(func(any) error)` / typed `SetCustomValidatorT(func(T) error)`

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -596,8 +596,8 @@ boa.CmdT[ThirdPartyConfig]{
         token.SetDescription("API token")   // like descr:"API token"
 
         port := boa.GetParamT(ctx, &p.Port)
-        port.SetMin(1)                      // like min:"1"
-        port.SetMax(65535)                  // like max:"65535"
+        port.SetMinT(1)                     // like min:"1"
+        port.SetMaxT(65535)                 // like max:"65535"
         port.SetRequired(true)              // like required:"true"
         return nil
     },
@@ -616,8 +616,8 @@ boa.CmdT[ThirdPartyConfig]{
 | `optional` / `opt` | `SetRequired(false)` |
 | `alts` / `alternatives` | `SetAlternatives([]string)`, `SetAlternativesFunc(...)` |
 | `strict` / `strict-alts` | `SetStrictAlts(bool)` |
-| `min` | `SetMin(float64)` (use `ClearMin()` to remove) |
-| `max` | `SetMax(float64)` (use `ClearMax()` to remove) |
+| `min` | `ParamT[T].SetMinT(T)` for numeric, `SetMinLen(int)` for string/slice/map. `ClearMin()` removes. Non-generic `Param.SetMin(any)` accepts any numeric (coerced to `*int64` / `*float64` / `*int` per field kind). |
+| `max` | `ParamT[T].SetMaxT(T)` / `SetMaxLen(int)` / `ClearMax()`. Symmetric with `min`. |
 | `pattern` | `SetPattern(string)` |
 | `boa:"noflag"` / `"nocli"` | `SetNoFlag(bool)` |
 | `boa:"noenv"` | `SetNoEnv(bool)` |

--- a/docs/bring-someone-elses-config.md
+++ b/docs/bring-someone-elses-config.md
@@ -51,8 +51,8 @@ func main() {
             port := boa.GetParamT(ctx, &p.Port)
             port.SetDescription("TCP port")
             port.SetDefaultT(8080)
-            port.SetMin(1)
-            port.SetMax(65535)
+            port.SetMinT(1)
+            port.SetMaxT(65535)
 
             // Hide the admin token from --help, still read from env/config
             token := boa.GetParamT(ctx, &p.AdminToken)
@@ -155,8 +155,8 @@ func main() {
             port := boa.GetParamT(ctx, &p.DB.Port)
             port.SetDescription("database port")
             port.SetDefaultT(5432)
-            port.SetMin(1)
-            port.SetMax(65535)
+            port.SetMinT(1)
+            port.SetMaxT(65535)
 
             // ─── CLI-only (env suppressed) ─────────────────────────────────
             // DebugMode is an interactive knob — we don't want a long-lived
@@ -184,8 +184,8 @@ func main() {
             tag.SetDescription("audit label written to every row")
             tag.SetNoFlag(true)
             tag.SetNoEnv(true)
-            tag.SetMin(3)
-            tag.SetMax(64)
+            tag.SetMinLen(3)
+            tag.SetMaxLen(64)
 
             // ─── Fully ignored by boa ──────────────────────────────────────
             // PoolSize comes from the driver's own config merging inside
@@ -257,7 +257,7 @@ func main() {
 |---|---|---|---|---|
 | `LogLevel` | `--log-level` | `$LOG_LEVEL` | yes | plain boa tag, own struct |
 | `DB.Host` | `--db-host` | `$DB_HOST` | yes | default + description via `InitFuncCtx` |
-| `DB.Port` | `--db-port` | `$DB_PORT` | yes | programmatic `SetMin` / `SetMax` |
+| `DB.Port` | `--db-port` | `$DB_PORT` | yes | programmatic `SetMinT` / `SetMaxT` |
 | `DB.User` | `--db-user` | `$DB_USER` | yes | custom validator (lowercase) |
 | `DB.Password` | — | `$DB_PASSWORD` | yes | `SetNoFlag(true)`, required |
 | `DB.SSLMode` | `--db-ssl-mode` | `$DB_SSL_MODE` | yes | enum via `SetAlternatives` + `SetStrictAlts` |
@@ -304,8 +304,8 @@ Every struct-tag feature has a matching method. The table below is the complete 
 | `optional` / `opt` | `SetRequired(false)` |
 | `alts` / `alternatives` | `SetAlternatives([]string)`, `SetAlternativesFunc(...)` |
 | `strict` / `strict-alts` | `SetStrictAlts(bool)` |
-| `min` | `SetMin(float64)` (use `ClearMin()` to remove) |
-| `max` | `SetMax(float64)` (use `ClearMax()` to remove) |
+| `min` | `ParamT[T].SetMinT(T)` for numeric; `SetMinLen(int)` for string/slice/map. `ClearMin()` removes. Non-generic `Param.SetMin(any)` accepts any numeric. |
+| `max` | `ParamT[T].SetMaxT(T)` / `SetMaxLen(int)` / `ClearMax()`. Symmetric with `min`. |
 | `pattern` | `SetPattern(string)` |
 | `boa:"noflag"` / `"nocli"` | `SetNoFlag(bool)` |
 | `boa:"noenv"` | `SetNoEnv(bool)` |
@@ -327,8 +327,8 @@ func wireDBConfig(ctx *boa.HookContext, db *dbconfig.Settings) {
     boa.GetParamT(ctx, &db.Port).SetDefaultT(5432)
 
     port := boa.GetParamT(ctx, &db.Port)
-    port.SetMin(1)
-    port.SetMax(65535)
+    port.SetMinT(1)
+    port.SetMaxT(65535)
 
     pwd := boa.GetParamT(ctx, &db.Password)
     pwd.SetNoFlag(true)

--- a/docs/struct-tags.md
+++ b/docs/struct-tags.md
@@ -98,14 +98,14 @@ boa.CmdT[ExternalConfig]{
         secret.SetEnv("APP_TOKEN")
 
         port := boa.GetParamT(ctx, &p.Port)
-        port.SetMin(1)            // equivalent to `min:"1"`
-        port.SetMax(65535)        // equivalent to `max:"65535"`
+        port.SetMinT(1)           // equivalent to `min:"1"`
+        port.SetMaxT(65535)       // equivalent to `max:"65535"`
         return nil
     },
 }
 ```
 
-Available setters include `SetDescription`, `SetName`, `SetShort`, `SetEnv`, `SetPositional`, `SetRequired(bool)` / `SetRequiredFn`, `SetNoFlag`, `SetNoEnv`, `SetIgnored`, `SetMin` / `ClearMin`, `SetMax` / `ClearMax`, `SetPattern`, `SetAlternatives`, `SetAlternativesFunc`, `SetStrictAlts`, `SetDefault` / `SetDefaultT`, `SetCustomValidator` / `SetCustomValidatorT`, and `SetIsEnabledFn`.
+Available setters include `SetDescription`, `SetName`, `SetShort`, `SetEnv`, `SetPositional`, `SetRequired(bool)` / `SetRequiredFn`, `SetNoFlag`, `SetNoEnv`, `SetIgnored`, `SetMinT(T)` / `SetMaxT(T)` for numeric fields, `SetMinLen(int)` / `SetMaxLen(int)` for string/slice/map fields, `ClearMin` / `ClearMax`, `SetPattern`, `SetAlternatives`, `SetAlternativesFunc`, `SetStrictAlts`, `SetDefault` / `SetDefaultT`, `SetCustomValidator` / `SetCustomValidatorT`, and `SetIsEnabledFn`. The numeric setters store at the field's natural precision (e.g. `int64` bounds past 2^53 round-trip losslessly), unlike the older float64-only API.
 
 All programmatic setters must be called from `InitFunc` / `InitFuncCtx` (or `CfgStructInit` / `CfgStructInitCtx`) so they take effect before cobra flag binding and env parsing.
 

--- a/pkg/boa/api_typed_param.go
+++ b/pkg/boa/api_typed_param.go
@@ -2,6 +2,7 @@
 package boa
 
 import (
+	"fmt"
 	"log/slog"
 	"reflect"
 
@@ -95,14 +96,23 @@ type ParamT[T any] interface {
 	// rather than a named flag. Cannot be combined with SetNoFlag(true).
 	SetPositional(positional bool)
 
-	// SetMin / SetMax set numeric/length bounds. For numeric types, the bound
-	// compares the value. For strings and slices, it compares length. Mirrors
-	// the `min:"..."` / `max:"..."` tags. Panics if called on a non-numeric /
-	// non-string / non-slice field (unlike the tag, which is silently ignored
-	// on unsupported types). Use ClearMin / ClearMax to remove a bound.
-	SetMin(min float64)
+	// SetMinT / SetMaxT set a typed numeric bound. Works on numeric fields
+	// (signed int, unsigned int, float). Panics on non-numeric T — use
+	// SetMinLen / SetMaxLen for string / slice / map fields instead. The
+	// stored bound uses the widest integer type for the field's signedness,
+	// so int64 bounds beyond 2^53 round-trip losslessly (unlike the old
+	// float64-only API).
+	SetMinT(min T)
+	SetMaxT(max T)
+
+	// SetMinLen / SetMaxLen set a length bound on a string / slice / map
+	// field. Panics on numeric T — use SetMinT / SetMaxT there instead.
+	SetMinLen(min int)
+	SetMaxLen(max int)
+
+	// ClearMin / ClearMax remove any previously set bound. Safe to call on
+	// any type.
 	ClearMin()
-	SetMax(max float64)
 	ClearMax()
 
 	// SetPattern sets a regex pattern that string values must match. Pass
@@ -278,9 +288,31 @@ func (w *ParamTView[T]) SetPositional(positional bool) {
 	w.param.SetPositional(positional)
 }
 
-// SetMin sets a lower bound. Use ClearMin to remove it.
-func (w *ParamTView[T]) SetMin(min float64) {
+// SetMinT sets a typed numeric lower bound. Panics if T is not numeric —
+// use SetMinLen for string / slice / map fields.
+func (w *ParamTView[T]) SetMinT(min T) {
+	assertNumericT[T]("SetMinT")
 	w.param.SetMin(min)
+}
+
+// SetMaxT sets a typed numeric upper bound. See SetMinT.
+func (w *ParamTView[T]) SetMaxT(max T) {
+	assertNumericT[T]("SetMaxT")
+	w.param.SetMax(max)
+}
+
+// SetMinLen sets a length lower bound on a string / slice / map field. Panics
+// if T is a numeric type — use SetMinT there instead.
+func (w *ParamTView[T]) SetMinLen(min int) {
+	assertLengthT[T]("SetMinLen")
+	w.param.SetMin(min)
+}
+
+// SetMaxLen sets a length upper bound on a string / slice / map field. See
+// SetMinLen.
+func (w *ParamTView[T]) SetMaxLen(max int) {
+	assertLengthT[T]("SetMaxLen")
+	w.param.SetMax(max)
 }
 
 // ClearMin removes a previously set lower bound.
@@ -288,14 +320,34 @@ func (w *ParamTView[T]) ClearMin() {
 	w.param.ClearMin()
 }
 
-// SetMax sets an upper bound. Use ClearMax to remove it.
-func (w *ParamTView[T]) SetMax(max float64) {
-	w.param.SetMax(max)
-}
-
 // ClearMax removes a previously set upper bound.
 func (w *ParamTView[T]) ClearMax() {
 	w.param.ClearMax()
+}
+
+// assertNumericT panics if T is not a numeric kind. Used to guard SetMinT /
+// SetMaxT at runtime since Go methods can't carry their own type constraints.
+func assertNumericT[T any](method string) {
+	var zero T
+	k := reflect.TypeOf(zero).Kind()
+	switch k {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return
+	}
+	panic(fmt.Errorf("boa: %s requires a numeric T, got %s — use SetMinLen / SetMaxLen for string/slice/map fields", method, k))
+}
+
+// assertLengthT panics if T is not a length-bearing kind (string, slice, map).
+func assertLengthT[T any](method string) {
+	var zero T
+	k := reflect.TypeOf(zero).Kind()
+	switch k {
+	case reflect.String, reflect.Slice, reflect.Map:
+		return
+	}
+	panic(fmt.Errorf("boa: %s requires a string / slice / map T, got %s — use SetMinT / SetMaxT for numeric fields", method, k))
 }
 
 // SetPattern sets a regex pattern (empty string clears).

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -201,13 +201,19 @@ type Param interface {
 	SetPositional(bool)
 
 	// GetMin / SetMin / ClearMin / GetMax / SetMax / ClearMax / GetPattern /
-	// SetPattern mirror the validation tags. GetMin / GetMax return nil when
-	// no bound is set; ClearMin / ClearMax remove a previously set bound.
-	GetMin() *float64
-	SetMin(float64)
+	// SetPattern mirror the validation tags. GetMin / GetMax return the bound
+	// as a typed pointer matching the field kind, or nil when no bound is set:
+	//   - signed int field   → *int64
+	//   - unsigned int field → *uint64
+	//   - float field        → *float64
+	//   - string/slice/map   → *int (length bound)
+	// SetMin / SetMax accept any numeric value; it's coerced to match the
+	// field kind. ClearMin / ClearMax remove a previously set bound.
+	GetMin() any
+	SetMin(any)
 	ClearMin()
-	GetMax() *float64
-	SetMax(float64)
+	GetMax() any
+	SetMax(any)
 	ClearMax()
 	GetPattern() string
 	SetPattern(string)
@@ -869,9 +875,51 @@ func validate(ctx *processingContext, structPtr any) error {
 	return newUserInputError(err)
 }
 
-// validateMinMaxPattern checks min/max/pattern tag constraints.
-// For numeric types, min/max compare the value.
-// For strings and slices, min/max compare length.
+// parseBoundTag parses a `min:"..."` or `max:"..."` tag value against the
+// field's boundKind. Returns a typed pointer matching the storage contract
+// of paramMeta.minVal / maxVal, or an error if the literal doesn't fit the
+// kind. Returns (nil, nil) when the field kind doesn't support min/max — the
+// tag is silently ignored (as it has always been) to preserve existing
+// behavior on unsupported types.
+func parseBoundTag(bk boundKind, s string) (any, error) {
+	switch bk {
+	case signedIntBound:
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected signed integer, got %q: %w", s, err)
+		}
+		return &v, nil
+	case unsignedIntBound:
+		v, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected unsigned integer, got %q: %w", s, err)
+		}
+		return &v, nil
+	case floatBound:
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected float, got %q: %w", s, err)
+		}
+		return &v, nil
+	case lengthBound:
+		v, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("expected non-negative integer length, got %q: %w", s, err)
+		}
+		if v < 0 {
+			return nil, fmt.Errorf("negative length %d", v)
+		}
+		n := int(v)
+		return &n, nil
+	}
+	return nil, nil
+}
+
+// validateMinMaxPattern checks min/max/pattern tag constraints. It dispatches
+// on the field's boundKind and compares against the typed-pointer bound stored
+// in pm.minVal / pm.maxVal. The storage type is guaranteed to match the field
+// kind (coerceBound enforces this at set time), so the type assertions here
+// never panic on a valid mirror.
 func validateMinMaxPattern(pm *paramMeta, valPtr any) error {
 	if pm.minVal == nil && pm.maxVal == nil && pm.pattern == "" {
 		return nil
@@ -882,38 +930,44 @@ func validateMinMaxPattern(pm *paramMeta, valPtr any) error {
 		v = v.Elem()
 	}
 
-	switch v.Kind() {
-	case reflect.Int, reflect.Int32, reflect.Int64:
-		val := float64(v.Int())
-		if pm.minVal != nil && val < *pm.minVal {
-			return fmt.Errorf("value %v is below min %v", v.Int(), *pm.minVal)
+	switch pm.boundKind() {
+	case signedIntBound:
+		val := v.Int()
+		if minP, ok := pm.minVal.(*int64); ok && minP != nil && val < *minP {
+			return fmt.Errorf("value %d is below min %d", val, *minP)
 		}
-		if pm.maxVal != nil && val > *pm.maxVal {
-			return fmt.Errorf("value %v exceeds max %v", v.Int(), *pm.maxVal)
+		if maxP, ok := pm.maxVal.(*int64); ok && maxP != nil && val > *maxP {
+			return fmt.Errorf("value %d exceeds max %d", val, *maxP)
 		}
-	case reflect.Float32, reflect.Float64:
+	case unsignedIntBound:
+		val := v.Uint()
+		if minP, ok := pm.minVal.(*uint64); ok && minP != nil && val < *minP {
+			return fmt.Errorf("value %d is below min %d", val, *minP)
+		}
+		if maxP, ok := pm.maxVal.(*uint64); ok && maxP != nil && val > *maxP {
+			return fmt.Errorf("value %d exceeds max %d", val, *maxP)
+		}
+	case floatBound:
 		val := v.Float()
-		if pm.minVal != nil && val < *pm.minVal {
-			return fmt.Errorf("value %v is below min %v", val, *pm.minVal)
+		if minP, ok := pm.minVal.(*float64); ok && minP != nil && val < *minP {
+			return fmt.Errorf("value %v is below min %v", val, *minP)
 		}
-		if pm.maxVal != nil && val > *pm.maxVal {
-			return fmt.Errorf("value %v exceeds max %v", val, *pm.maxVal)
+		if maxP, ok := pm.maxVal.(*float64); ok && maxP != nil && val > *maxP {
+			return fmt.Errorf("value %v exceeds max %v", val, *maxP)
 		}
-	case reflect.String:
-		str := v.String()
-		if pm.minVal != nil && float64(len(str)) < *pm.minVal {
-			return fmt.Errorf("length %d is below min %v", len(str), *pm.minVal)
+	case lengthBound:
+		var l int
+		switch v.Kind() {
+		case reflect.String:
+			l = len(v.String())
+		case reflect.Slice, reflect.Map:
+			l = v.Len()
 		}
-		if pm.maxVal != nil && float64(len(str)) > *pm.maxVal {
-			return fmt.Errorf("length %d exceeds max %v", len(str), *pm.maxVal)
+		if minP, ok := pm.minVal.(*int); ok && minP != nil && l < *minP {
+			return fmt.Errorf("length %d is below min %d", l, *minP)
 		}
-	case reflect.Slice:
-		l := v.Len()
-		if pm.minVal != nil && float64(l) < *pm.minVal {
-			return fmt.Errorf("length %d is below min %v", l, *pm.minVal)
-		}
-		if pm.maxVal != nil && float64(l) > *pm.maxVal {
-			return fmt.Errorf("length %d exceeds max %v", l, *pm.maxVal)
+		if maxP, ok := pm.maxVal.(*int); ok && maxP != nil && l > *maxP {
+			return fmt.Errorf("length %d exceeds max %d", l, *maxP)
 		}
 	}
 
@@ -1750,18 +1804,22 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// Parse min/max/pattern validation tags
 			if pm, ok := param.(*paramMeta); ok {
 				if minStr, ok := tags.Lookup("min"); ok {
-					v, err := strconv.ParseFloat(minStr, 64)
+					ptr, err := parseBoundTag(pm.boundKind(), minStr)
 					if err != nil {
 						return fmt.Errorf("invalid min value for param %s: %s", param.GetName(), err.Error())
 					}
-					pm.minVal = &v
+					if ptr != nil {
+						pm.minVal = ptr
+					}
 				}
 				if maxStr, ok := tags.Lookup("max"); ok {
-					v, err := strconv.ParseFloat(maxStr, 64)
+					ptr, err := parseBoundTag(pm.boundKind(), maxStr)
 					if err != nil {
 						return fmt.Errorf("invalid max value for param %s: %s", param.GetName(), err.Error())
 					}
-					pm.maxVal = &v
+					if ptr != nil {
+						pm.maxVal = ptr
+					}
 				}
 				if pat, ok := tags.Lookup("pattern"); ok {
 					pm.pattern = pat

--- a/pkg/boa/noflag_test.go
+++ b/pkg/boa/noflag_test.go
@@ -530,8 +530,8 @@ func TestSetMinMax_Programmatic(t *testing.T) {
 		ParamEnrich: ParamEnricherName,
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 			p := GetParamT(ctx, &params.Port)
-			p.SetMin(1)
-			p.SetMax(100)
+			p.SetMinT(1)
+			p.SetMaxT(100)
 			return nil
 		},
 		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -628,45 +628,97 @@ func TestSetRequired_ProgrammaticFalse(t *testing.T) {
 	}
 }
 
-// --- SetMin / SetMax / SetPattern type guards ---
+// --- SetMinT / SetMaxT / SetPattern type guards ---
 
-func TestSetMin_PanicsOnUnsupportedType(t *testing.T) {
+func TestSetMinT_PanicsOnUnsupportedType(t *testing.T) {
+	// bool isn't numeric and isn't length-based — SetMinT must panic with the
+	// "numeric T required" message.
 	type Params struct {
 		Flag bool `optional:"true"`
 	}
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Fatal("expected SetMin on bool to panic")
+			t.Fatal("expected SetMinT on bool to panic")
 		}
-		if !strings.Contains(fmt.Sprint(r), "SetMin") {
-			t.Errorf("expected panic mentioning SetMin, got: %v", r)
+		if !strings.Contains(fmt.Sprint(r), "SetMinT") {
+			t.Errorf("expected panic mentioning SetMinT, got: %v", r)
 		}
 	}()
 	_ = (CmdT[Params]{
 		Use: "test",
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
-			GetParamT(ctx, &params.Flag).SetMin(1)
+			GetParamT(ctx, &params.Flag).SetMinT(true)
 			return nil
 		},
 		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
 	}).RunArgsE([]string{})
 }
 
-func TestSetMax_PanicsOnUnsupportedType(t *testing.T) {
+func TestSetMaxT_PanicsOnUnsupportedType(t *testing.T) {
 	type Params struct {
 		Flag bool `optional:"true"`
 	}
 	defer func() {
 		r := recover()
 		if r == nil {
-			t.Fatal("expected SetMax on bool to panic")
+			t.Fatal("expected SetMaxT on bool to panic")
 		}
 	}()
 	_ = (CmdT[Params]{
 		Use: "test",
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
-			GetParamT(ctx, &params.Flag).SetMax(1)
+			GetParamT(ctx, &params.Flag).SetMaxT(true)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+}
+
+func TestSetMinT_PanicsOnStringField(t *testing.T) {
+	// string is length-based — SetMinT must redirect to SetMinLen.
+	type Params struct {
+		Name string `optional:"true"`
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected SetMinT on string to panic")
+		}
+		msg := fmt.Sprint(r)
+		if !strings.Contains(msg, "SetMinLen") {
+			t.Errorf("expected panic to recommend SetMinLen, got: %v", r)
+		}
+	}()
+	_ = (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &params.Name).SetMinT("abc")
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+}
+
+func TestSetMinLen_PanicsOnNumericField(t *testing.T) {
+	// int is numeric — SetMinLen must redirect to SetMinT.
+	type Params struct {
+		Port int `optional:"true"`
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected SetMinLen on int to panic")
+		}
+		msg := fmt.Sprint(r)
+		if !strings.Contains(msg, "SetMinT") {
+			t.Errorf("expected panic to recommend SetMinT, got: %v", r)
+		}
+	}()
+	_ = (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &params.Port).SetMinLen(1)
 			return nil
 		},
 		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -726,8 +778,8 @@ func TestSetMin_Programmatic_BelowIntMin(t *testing.T) {
 		ParamEnrich: ParamEnricherName,
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 			p := GetParamT(ctx, &params.Port)
-			p.SetMin(10)
-			p.SetMax(100)
+			p.SetMinT(10)
+			p.SetMaxT(100)
 			return nil
 		},
 		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -759,8 +811,8 @@ func TestSetMinMax_Programmatic_Float(t *testing.T) {
 				ParamEnrich: ParamEnricherName,
 				InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 					p := GetParamT(ctx, &params.Rate)
-					p.SetMin(0)
-					p.SetMax(1)
+					p.SetMinT(0)
+					p.SetMaxT(1)
 					return nil
 				},
 				RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -781,7 +833,7 @@ func TestSetMinMax_Programmatic_Float(t *testing.T) {
 	}
 }
 
-func TestSetMinMax_Programmatic_StringLength(t *testing.T) {
+func TestSetMinMaxLen_Programmatic_StringLength(t *testing.T) {
 	type Params struct {
 		Name string `descr:"name" optional:"true"`
 	}
@@ -791,8 +843,8 @@ func TestSetMinMax_Programmatic_StringLength(t *testing.T) {
 			ParamEnrich: ParamEnricherName,
 			InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 				p := GetParamT(ctx, &params.Name)
-				p.SetMin(3)
-				p.SetMax(10)
+				p.SetMinLen(3)
+				p.SetMaxLen(10)
 				return nil
 			},
 			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -809,7 +861,7 @@ func TestSetMinMax_Programmatic_StringLength(t *testing.T) {
 	}
 }
 
-func TestSetMinMax_Programmatic_SliceLength(t *testing.T) {
+func TestSetMinMaxLen_Programmatic_SliceLength(t *testing.T) {
 	type Params struct {
 		Tags []string `descr:"tags" optional:"true"`
 	}
@@ -819,8 +871,8 @@ func TestSetMinMax_Programmatic_SliceLength(t *testing.T) {
 			ParamEnrich: ParamEnricherName,
 			InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 				p := GetParamT(ctx, &params.Tags)
-				p.SetMin(2)
-				p.SetMax(3)
+				p.SetMinLen(2)
+				p.SetMaxLen(3)
 				return nil
 			},
 			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
@@ -847,8 +899,8 @@ func TestClearMinMax_Programmatic_RemovesBound(t *testing.T) {
 		ParamEnrich: ParamEnricherName,
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 			p := GetParamT(ctx, &params.Port)
-			p.SetMin(10)
-			p.SetMax(20)
+			p.SetMinT(10)
+			p.SetMaxT(20)
 			p.ClearMin()
 			p.ClearMax()
 			return nil
@@ -860,22 +912,23 @@ func TestClearMinMax_Programmatic_RemovesBound(t *testing.T) {
 	}
 }
 
-func TestSetMin_Programmatic_GetMinRoundTrip(t *testing.T) {
-	// SetMin / GetMin should round-trip, and ClearMin should reset to nil.
-	// GetMin / GetMax live on the non-generic Param interface (the typed view
-	// only exposes setters), so we read them via ctx.GetParam.
+func TestSetMinMax_Programmatic_GetRoundTrip(t *testing.T) {
+	// SetMinT / GetMin should round-trip at full int precision, and
+	// ClearMin should reset to nil. GetMin / GetMax live on the non-generic
+	// Param interface (the typed view only exposes setters), so we read them
+	// via ctx.GetParam. Int fields store as *int64.
 	type Params struct {
 		Port int `descr:"port" optional:"true"`
 	}
-	var sawMinSet, sawMinCleared *float64
-	var sawMaxSet, sawMaxCleared *float64
+	var sawMinSet, sawMinCleared any
+	var sawMaxSet, sawMaxCleared any
 	err := (CmdT[Params]{
 		Use:         "test",
 		ParamEnrich: ParamEnricherName,
 		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
 			tp := GetParamT(ctx, &params.Port)
-			tp.SetMin(42)
-			tp.SetMax(99)
+			tp.SetMinT(42)
+			tp.SetMaxT(99)
 
 			raw := ctx.GetParam(&params.Port)
 			sawMinSet = raw.GetMin()
@@ -892,17 +945,19 @@ func TestSetMin_Programmatic_GetMinRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if sawMinSet == nil || *sawMinSet != 42 {
-		t.Errorf("expected GetMin to return 42 after SetMin, got: %v", sawMinSet)
+	minP, ok := sawMinSet.(*int64)
+	if !ok || minP == nil || *minP != 42 {
+		t.Errorf("expected GetMin to return *int64(42), got: %T %v", sawMinSet, sawMinSet)
 	}
-	if sawMaxSet == nil || *sawMaxSet != 99 {
-		t.Errorf("expected GetMax to return 99 after SetMax, got: %v", sawMaxSet)
+	maxP, ok := sawMaxSet.(*int64)
+	if !ok || maxP == nil || *maxP != 99 {
+		t.Errorf("expected GetMax to return *int64(99), got: %T %v", sawMaxSet, sawMaxSet)
 	}
 	if sawMinCleared != nil {
-		t.Errorf("expected GetMin to return nil after ClearMin, got: %v", *sawMinCleared)
+		t.Errorf("expected GetMin to return nil after ClearMin, got: %v", sawMinCleared)
 	}
 	if sawMaxCleared != nil {
-		t.Errorf("expected GetMax to return nil after ClearMax, got: %v", *sawMaxCleared)
+		t.Errorf("expected GetMax to return nil after ClearMax, got: %v", sawMaxCleared)
 	}
 }
 

--- a/pkg/boa/param_meta.go
+++ b/pkg/boa/param_meta.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math"
 	"reflect"
 
 	"github.com/spf13/cobra"
@@ -56,9 +57,18 @@ type paramMeta struct {
 
 	// Validation
 	customValidator func(any) error
-	minVal          *float64 // min value (numeric) or min length (string)
-	maxVal          *float64 // max value (numeric) or max length (string)
-	pattern         string   // regex pattern for string validation
+	// minVal / maxVal hold the bound as a typed pointer. The concrete type
+	// depends on the field kind:
+	//   - signed int field   → *int64
+	//   - unsigned int field → *uint64
+	//   - float field        → *float64
+	//   - string/slice/map   → *int (length bound)
+	// nil means "no bound". The typed storage keeps int64 bounds lossless
+	// past 2^53, which is the whole point of going through an any here
+	// instead of always-float64.
+	minVal  any
+	maxVal  any
+	pattern string // regex pattern for string validation
 
 	// noFlag indicates the field should not be registered as a CLI flag,
 	// but is still populated from env vars and config files. Set via the
@@ -338,20 +348,38 @@ func (f *paramMeta) SetIgnored(val bool) { f.ignored = val }
 
 // --- min / max / pattern ---
 
-// supportsMinMax reports whether this param's underlying type is one the
-// min/max validator will actually check (numeric value, or length for
-// string/slice). Keep this in sync with validateMinMaxPattern's switch.
-func (f *paramMeta) supportsMinMax() bool {
-	switch f.fieldType.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64,
-		reflect.String,
-		reflect.Slice:
-		return true
+// boundKind classifies a field type for min/max purposes. It collapses the
+// reflect.Kind zoo into the four shapes a bound actually has: signed int,
+// unsigned int, float, or length (string/slice/map). unsupportedBound means
+// min/max are meaningless on this field.
+type boundKind int
+
+const (
+	unsupportedBound boundKind = iota
+	signedIntBound
+	unsignedIntBound
+	floatBound
+	lengthBound
+)
+
+// boundKindOf returns the boundKind for a reflect.Type. Uses Kind() so type
+// aliases (e.g., `type Port int`) work transparently.
+func boundKindOf(t reflect.Type) boundKind {
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return signedIntBound
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return unsignedIntBound
+	case reflect.Float32, reflect.Float64:
+		return floatBound
+	case reflect.String, reflect.Slice, reflect.Map:
+		return lengthBound
 	}
-	return false
+	return unsupportedBound
 }
+
+// boundKind returns this param's boundKind.
+func (f *paramMeta) boundKind() boundKind { return boundKindOf(f.fieldType) }
 
 // supportsPattern reports whether this param's underlying type is one the
 // pattern validator will act on (strings only).
@@ -359,56 +387,167 @@ func (f *paramMeta) supportsPattern() bool {
 	return f.fieldType.Kind() == reflect.String
 }
 
-func (f *paramMeta) GetMin() *float64 {
-	if f.minVal == nil {
-		return nil
+// coerceBound takes a caller-provided value and normalizes it to the storage
+// type for the given boundKind. Accepts any numeric value (int/uint/float
+// widths) as long as it fits the target kind. Returns an error with a human
+// message if the input is the wrong shape (e.g. float bound on an int field,
+// or negative length).
+func coerceBound(raw any, bk boundKind) (any, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("nil bound")
 	}
-	v := *f.minVal
-	return &v
+	rv := reflect.ValueOf(raw)
+	// Unwrap a single level of pointer, e.g. caller passed *int64.
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, fmt.Errorf("nil bound")
+		}
+		rv = rv.Elem()
+	}
+	switch bk {
+	case signedIntBound:
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v := rv.Int()
+			return &v, nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			u := rv.Uint()
+			if u > math.MaxInt64 {
+				return nil, fmt.Errorf("bound %d overflows int64", u)
+			}
+			v := int64(u)
+			return &v, nil
+		case reflect.Float32, reflect.Float64:
+			return nil, fmt.Errorf("float bound on signed-int field is lossy; pass an int value instead")
+		}
+	case unsignedIntBound:
+		switch rv.Kind() {
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			v := rv.Uint()
+			return &v, nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			i := rv.Int()
+			if i < 0 {
+				return nil, fmt.Errorf("negative bound %d on unsigned-int field", i)
+			}
+			v := uint64(i)
+			return &v, nil
+		case reflect.Float32, reflect.Float64:
+			return nil, fmt.Errorf("float bound on unsigned-int field is lossy; pass an int value instead")
+		}
+	case floatBound:
+		switch rv.Kind() {
+		case reflect.Float32, reflect.Float64:
+			v := rv.Float()
+			return &v, nil
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v := float64(rv.Int())
+			return &v, nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			v := float64(rv.Uint())
+			return &v, nil
+		}
+	case lengthBound:
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			i := rv.Int()
+			if i < 0 {
+				return nil, fmt.Errorf("negative length bound %d", i)
+			}
+			v := int(i)
+			return &v, nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			u := rv.Uint()
+			if u > math.MaxInt {
+				return nil, fmt.Errorf("length bound %d overflows int", u)
+			}
+			v := int(u)
+			return &v, nil
+		case reflect.Float32, reflect.Float64:
+			return nil, fmt.Errorf("float length bound is not allowed; pass an int")
+		}
+	}
+	return nil, fmt.Errorf("unsupported bound value of type %T", raw)
 }
 
-// SetMin sets a lower bound. Panics if called on a field whose type cannot be
-// min/max validated (anything outside numeric / string / slice). The equivalent
-// struct tag (`min:"..."`) is silently no-op'd on unsupported types today — the
-// programmatic API is stricter because the caller has the type in hand and a
-// silent no-op is a foot-gun. Use ClearMin to remove a previously set bound.
-func (f *paramMeta) SetMin(val float64) {
-	if !f.supportsMinMax() {
-		panic(fmt.Errorf("boa: SetMin on %q: type %s is not a numeric, string, or slice — min is only meaningful on those", f.name, f.fieldType.Kind()))
+// GetMin returns a copy of the current lower bound, or nil if none is set.
+// The concrete type is one of *int64 / *uint64 / *float64 / *int depending on
+// the field kind.
+func (f *paramMeta) GetMin() any { return copyBound(f.minVal) }
+
+// GetMax returns a copy of the current upper bound. See GetMin for the
+// concrete type dispatch.
+func (f *paramMeta) GetMax() any { return copyBound(f.maxVal) }
+
+// copyBound returns a defensive copy of a stored typed-pointer bound.
+func copyBound(b any) any {
+	switch v := b.(type) {
+	case nil:
+		return nil
+	case *int64:
+		if v == nil {
+			return nil
+		}
+		out := *v
+		return &out
+	case *uint64:
+		if v == nil {
+			return nil
+		}
+		out := *v
+		return &out
+	case *float64:
+		if v == nil {
+			return nil
+		}
+		out := *v
+		return &out
+	case *int:
+		if v == nil {
+			return nil
+		}
+		out := *v
+		return &out
 	}
-	v := val
-	f.minVal = &v
+	return nil
+}
+
+// SetMin sets a lower bound. Accepts any numeric value; it's coerced to the
+// storage type that matches the field's boundKind. Panics if the field type
+// cannot carry a bound or if the provided value has the wrong shape. Use
+// ClearMin to remove a previously set bound.
+func (f *paramMeta) SetMin(val any) {
+	bk := f.boundKind()
+	if bk == unsupportedBound {
+		panic(fmt.Errorf("boa: SetMin on %q: type %s is not a numeric, string, slice, or map — min is only meaningful on those", f.name, f.fieldType.Kind()))
+	}
+	coerced, err := coerceBound(val, bk)
+	if err != nil {
+		panic(fmt.Errorf("boa: SetMin on %q: %w", f.name, err))
+	}
+	f.minVal = coerced
 }
 
 // ClearMin removes any lower bound previously set on this parameter. Safe to
 // call on any type.
-func (f *paramMeta) ClearMin() {
-	f.minVal = nil
-}
+func (f *paramMeta) ClearMin() { f.minVal = nil }
 
-func (f *paramMeta) GetMax() *float64 {
-	if f.maxVal == nil {
-		return nil
+// SetMax sets an upper bound. See SetMin for the type rules.
+func (f *paramMeta) SetMax(val any) {
+	bk := f.boundKind()
+	if bk == unsupportedBound {
+		panic(fmt.Errorf("boa: SetMax on %q: type %s is not a numeric, string, slice, or map — max is only meaningful on those", f.name, f.fieldType.Kind()))
 	}
-	v := *f.maxVal
-	return &v
-}
-
-// SetMax sets an upper bound. See SetMin for the type restriction. Use
-// ClearMax to remove a previously set bound.
-func (f *paramMeta) SetMax(val float64) {
-	if !f.supportsMinMax() {
-		panic(fmt.Errorf("boa: SetMax on %q: type %s is not a numeric, string, or slice — max is only meaningful on those", f.name, f.fieldType.Kind()))
+	coerced, err := coerceBound(val, bk)
+	if err != nil {
+		panic(fmt.Errorf("boa: SetMax on %q: %w", f.name, err))
 	}
-	v := val
-	f.maxVal = &v
+	f.maxVal = coerced
 }
 
 // ClearMax removes any upper bound previously set on this parameter. Safe to
 // call on any type.
-func (f *paramMeta) ClearMax() {
-	f.maxVal = nil
-}
+func (f *paramMeta) ClearMax() { f.maxVal = nil }
 
 func (f *paramMeta) GetPattern() string { return f.pattern }
 

--- a/pkg/boa/typed_minmax_test.go
+++ b/pkg/boa/typed_minmax_test.go
@@ -1,0 +1,265 @@
+package boa
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// --- int64 precision: the whole point of the typed-storage refactor ---
+
+// TestValidationTag_Int64_PrecisionBug exercises the specific correctness gap
+// the pre-refactor float64 pipeline had. With the old code:
+//
+//	max := float64(1 << 53)     // = 9007199254740992
+//	val := float64(1<<53 + 1)   // rounds to 9007199254740992 (!!)
+//	val > max                   // false → value (1<<53 + 1) passed validation
+//
+// Post-refactor the bound is stored as *int64 and v.Int() returns int64, so
+// the comparison is lossless. This test fails loudly on any regression.
+func TestValidationTag_Int64_PrecisionBug(t *testing.T) {
+	// 2^53 is exactly representable in float64; 2^53+1 is not (it rounds to
+	// 2^53). So if the bound is 2^53 and the input is 2^53+1, the old
+	// float64-based comparison said "equal" and let it through.
+	const maxStr = "9007199254740992"          // 2^53
+	const cheatingVal = "9007199254740993"     // 2^53 + 1 — must be rejected
+
+	type Params struct {
+		N int64 `descr:"n" max:"9007199254740992"`
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", maxStr})
+	if err != nil {
+		t.Fatalf("value == max (2^53) should pass, got: %v", err)
+	}
+
+	err = (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", cheatingVal})
+	if err == nil {
+		t.Fatalf("value = 2^53+1 with max=2^53 must be rejected (this was the precision bug)")
+	}
+	if !strings.Contains(err.Error(), "max") {
+		t.Errorf("expected error mentioning 'max', got: %v", err)
+	}
+}
+
+// TestSetMaxT_Int64_PrecisionBug does the same check via the typed
+// programmatic API.
+func TestSetMaxT_Int64_PrecisionBug(t *testing.T) {
+	const max = int64(1 << 53)     // 9007199254740992, exactly representable in f64
+	const cheating = max + 1       // 9007199254740993, rounds down in f64
+
+	type Params struct {
+		N int64 `descr:"n" optional:"true"`
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &params.N).SetMaxT(max)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", strconv.FormatInt(cheating, 10)})
+	if err == nil || !strings.Contains(err.Error(), "max") {
+		t.Fatalf("value 2^53+1 with max=2^53 must be rejected, got: %v", err)
+	}
+}
+
+// TestValidationTag_Int64_MaxBoundary validates that math.MaxInt64 itself is
+// parseable as a tag and is enforced exactly.
+func TestValidationTag_Int64_MaxBoundary(t *testing.T) {
+	type Params struct {
+		N int64 `descr:"n" max:"9223372036854775807"` // math.MaxInt64
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", "9223372036854775807"})
+	if err != nil {
+		t.Fatalf("math.MaxInt64 should pass == max, got: %v", err)
+	}
+}
+
+// Note on uint / int8 / int16 fields: boa's type_handler.go only registers
+// CLI handlers for Int, Int32, Int64, Float32, Float64. Unsigned and narrow
+// signed kinds aren't valid field types today — the field traversal rejects
+// them — so we don't test min/max against them. The boundKind classifier
+// still has a signedIntBound / unsignedIntBound split as forward compat for
+// when those kinds get first-class handler support.
+
+// --- map length bound (previously not supported; CLAUDE.md mentioned maps
+//     but supportsMinMax never returned true for reflect.Map) ---
+
+func TestValidationTag_MapLength(t *testing.T) {
+	type Params struct {
+		Labels map[string]string `descr:"labels" min:"2" max:"3" optional:"true"`
+	}
+	// 1 entry → below min
+	if err := (CmdT[Params]{
+		Use: "test", ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--labels", "a=1"}); err == nil || !strings.Contains(err.Error(), "min") {
+		t.Errorf("expected min error for 1-entry map, got: %v", err)
+	}
+	// 4 entries → above max
+	if err := (CmdT[Params]{
+		Use: "test", ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--labels", "a=1,b=2,c=3,d=4"}); err == nil || !strings.Contains(err.Error(), "max") {
+		t.Errorf("expected max error for 4-entry map, got: %v", err)
+	}
+	// 2 entries → valid
+	if err := (CmdT[Params]{
+		Use: "test", ParamEnrich: ParamEnricherName,
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--labels", "a=1,b=2"}); err != nil {
+		t.Errorf("expected no error for 2-entry map, got: %v", err)
+	}
+}
+
+func TestSetMinMaxLen_Programmatic_Map(t *testing.T) {
+	type Params struct {
+		Labels map[string]string `descr:"labels" optional:"true"`
+	}
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			p := GetParamT(ctx, &params.Labels)
+			p.SetMinLen(2)
+			p.SetMaxLen(3)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--labels", "a=1"})
+	if err == nil || !strings.Contains(err.Error(), "min") {
+		t.Fatalf("expected min error for 1-entry map, got: %v", err)
+	}
+}
+
+// --- type-alias fields behave like their underlying kind ---
+
+func TestSetMinMaxT_TypeAlias(t *testing.T) {
+	type Port int32
+	type Params struct {
+		P Port `descr:"p" optional:"true"`
+	}
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			p := GetParamT(ctx, &params.P)
+			p.SetMinT(Port(1))
+			p.SetMaxT(Port(100))
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--p", "500"})
+	if err == nil || !strings.Contains(err.Error(), "max") {
+		t.Fatalf("expected max error for type-aliased int32, got: %v", err)
+	}
+}
+
+// --- tag parser rejects garbage per-kind ---
+
+func TestValidationTag_MinMax_RejectsFloatOnIntField(t *testing.T) {
+	type Params struct {
+		N int `descr:"n" min:"1.5"`
+	}
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", "5"})
+	if err == nil || !strings.Contains(err.Error(), "invalid min") {
+		t.Errorf("expected tag parse error, got: %v", err)
+	}
+}
+
+func TestValidationTag_MinMax_RejectsNegativeLengthOnSlice(t *testing.T) {
+	type Params struct {
+		Xs []string `descr:"xs" min:"-1" optional:"true"`
+	}
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+	if err == nil || !strings.Contains(err.Error(), "invalid min") {
+		t.Errorf("expected tag parse error on negative length, got: %v", err)
+	}
+}
+
+// --- programmatic setter rejects float bound on int field ---
+
+func TestSetMin_RejectsFloatBoundOnIntField(t *testing.T) {
+	type Params struct {
+		N int `descr:"n" optional:"true"`
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when setting float bound on int field")
+		}
+		if !strings.Contains(strings.ToLower(strings.ReplaceAll(
+			// safe stringify
+			toString(r), "\n", " ")), "float") {
+			t.Errorf("expected panic to mention 'float', got: %v", r)
+		}
+	}()
+	_ = (CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			ctx.GetParam(&params.N).SetMin(1.5)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+}
+
+// toString is a tiny helper to avoid importing fmt just for panic stringify.
+func toString(v any) string {
+	if s, ok := v.(interface{ Error() string }); ok {
+		return s.Error()
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// --- non-generic Param.SetMin accepts any numeric ---
+
+func TestParamSetMin_AcceptsAnyNumericOnIntField(t *testing.T) {
+	type Params struct {
+		N int `descr:"n" optional:"true"`
+	}
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, params *Params, cmd *cobra.Command) error {
+			p := ctx.GetParam(&params.N)
+			// An int8 value should be coerced into the *int64 storage.
+			p.SetMin(int8(5))
+			p.SetMax(int16(10))
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--n", "3"})
+	if err == nil || !strings.Contains(err.Error(), "min") {
+		t.Fatalf("expected min error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace float64-only min/max storage with typed pointers (`*int64` / `*float64` / `*int`) dispatched on field `boundKind`. Fixes a silent correctness bug where `int64` bounds past 2^53 were truncated through `strconv.ParseFloat` and float64-cast comparisons.
- New `ParamT[T]` API: `SetMinT(T)` / `SetMaxT(T)` for numeric fields, `SetMinLen(int)` / `SetMaxLen(int)` for string / slice / map. Non-generic `Param.GetMin` / `SetMin` / `GetMax` / `SetMax` now take `any` (a typed pointer matching the field kind).
- Kind-aware tag parser (`ParseInt` / `ParseFloat` per kind), kind-dispatched validation, map length bounds actually work now (they were silently broken — `supportsMinMax` claimed support but the validator never switched on `reflect.Map`).

## The precision bug, concretely

Old path:
```go
max := float64(1 << 53)         // 9007199254740992, exact in f64
val := float64(int64(1<<53)+1)  // rounds to 9007199254740992 (!!)
val > max                       // false → value (1<<53 + 1) passed validation
```

New path:
```go
*pm.maxVal = int64(1 << 53)     // *int64 storage, no f64 conversion
v.Int() > *max                  // int64-vs-int64, lossless up to math.MaxInt64
```

See `TestValidationTag_Int64_PrecisionBug` and `TestSetMaxT_Int64_PrecisionBug` in `pkg/boa/typed_minmax_test.go`.

## Test plan

- [x] ` + "`" + `go test ./...` + "`" + ` green on the refactor branch
- [x] New int64 precision regression test covers both tag parser and `SetMaxT` (would fail against old code)
- [x] `math.MaxInt64` boundary test
- [x] Map length bound tests (tag + programmatic) — previously silently no-op'd
- [x] Type alias coverage (`type Port int32` via `SetMinT` / `SetMaxT`)
- [x] Tag parser rejection cases: float-on-int, negative length
- [x] Programmatic `SetMin` panic for float bound on int field
- [x] Non-generic `Param.SetMin` accepts any numeric (int8/int16/… coerced)
- [x] Existing programmatic tests in `noflag_test.go` migrated to the new `SetMinT` / `SetMaxT` / `SetMinLen` / `SetMaxLen` API

## Notes for reviewer

- `boundKind` has a `signedIntBound` / `unsignedIntBound` split as forward compat. `type_handler.go` today only registers handlers for `Int / Int32 / Int64 / Float32 / Float64`, so `unsignedIntBound` is reachable via `coerceBound` / `parseBoundTag` but not exercisable through real fields until uint handlers land — intentionally left in place so min/max doesn't need a second refactor when that happens.
- `Param.SetMin(any)` is the new low-level hook. Typed view methods coerce at the boundary, so callers who stick with `SetMinT` / `SetMinLen` never touch `any` directly.
- No backwards-compat shim. The previous `SetMin(float64)` / `SetMax(float64)` were very new (#30) and per earlier discussion nobody depends on them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced generic min/max constraint API with type-specific methods for improved type safety
  * Added dedicated length-constraint methods for strings, slices, and maps

* **Bug Fixes**
  * Enhanced numeric boundary validation precision to prevent loss of precision in large integer comparisons

* **Documentation**
  * Updated all documentation examples and guides to reflect the new constraint API changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->