### PR TITLE
feat: SetConfigFile programmatic setter + embed pattern for external structs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Every struct-tag feature has a matching method on `Param` / `ParamT[T]` so field
 - `SetNoFlag(bool)` / `IsNoFlag() bool` — mirrors `boa:"noflag"`
 - `SetNoEnv(bool)` / `IsNoEnv() bool` — mirrors `boa:"noenv"`
 - `SetIgnored(bool)` / `IsIgnored() bool` — post-traversal equivalent of `boa:"ignore"` (the tag itself skips traversal entirely, so the mirror never exists; the programmatic form marks an existing mirror as ignored so CLI/env/validation/sync are all skipped). For `boa:"configonly"`, call `SetNoFlag(true)` + `SetNoEnv(true)` instead.
+- `SetConfigFile(bool)` / `IsConfigFile() bool` — programmatic equivalent of `configfile:"true"`. Field must be a string; tag-processing pass normalizes both tag and programmatic flag into a single config-file registry entry, so either source works identically. Non-string fields produce a clean user-input error rather than a panic.
 - `SetMinT(T)` / `SetMaxT(T)` on `ParamT[T]` for numeric `T` (stores at full int64/float64 precision). `SetMinLen(int)` / `SetMaxLen(int)` for string / slice / map fields. `ClearMin()` / `ClearMax()` on both. The non-generic `Param` exposes `GetMin() any` / `SetMin(any)` / `ClearMin()` (same for Max), returning a typed pointer: `*int64` for signed ints, `*float64` for floats, `*int` for length-based fields. `SetPattern(string)` / `GetPattern() string` unchanged.
 - `SetDefault(any)` / typed `ParamT[T].SetDefaultT(T)`
 - `SetAlternatives([]string)`, `SetAlternativesFunc(...)`, `SetStrictAlts(bool)`

--- a/docs/bring-someone-elses-config.md
+++ b/docs/bring-someone-elses-config.md
@@ -311,6 +311,7 @@ Every struct-tag feature has a matching method. The table below is the complete 
 | `boa:"noenv"` | `SetNoEnv(bool)` |
 | `boa:"configonly"` | `SetNoFlag(true)` + `SetNoEnv(true)` |
 | `boa:"ignore"` | `SetIgnored(bool)` (post-traversal equivalent) |
+| `configfile:"true"` | `SetConfigFile(bool)` — field must be a string |
 
 All of these must be called from a hook that runs **before cobra flag binding** — that is, `InitFunc`, `InitFuncCtx`, or the `CfgStructInit` / `CfgStructInitCtx` interfaces. Calling them later (in `PostCreate*` or `RunFunc`) is too late: the flags are already wired up.
 
@@ -342,11 +343,113 @@ InitFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command) error {
 },
 ```
 
+## Auto-config-file loading for an external struct
+
+You have **two ways** to point `configfile` at a field inside an external struct:
+
+1. **Programmatic `SetConfigFile(true)`** — add a plain string field to the params struct (or to a wrapper) and mark it from `InitFuncCtx`.
+2. **Anonymous embedding** — wrap the external struct in your own type and put a `configfile:"true"` field on the wrapper.
+
+Both end up at the same place (BOA's config-file registry); pick whichever reads better for the call site. Below are three flavors of the embedding variant, from most-ceremonial to least.
+
+### Variant A — named wrapper type
+
+Anonymous embedding lets you bolt a tagged config-file field onto an external struct without modifying it. The wrapper becomes your params type; boa walks the embedded fields at the root level (no prefix), and JSON/YAML/TOML unmarshal flattens embedded fields the same way, so a single config file populates them directly:
+
+```go
+// externalpkg.Settings is third-party — no boa tags, no configfile field.
+//
+// type Settings struct {
+//     Host string
+//     Port int
+// }
+
+type Params struct {
+    externalpkg.Settings        // anonymous embed — fields land at the root
+    ConfigFile           string `configfile:"true" optional:"true" descr:"path to config file"`
+}
+
+func main() {
+    boa.CmdT[Params]{
+        Use: "app",
+        ParamEnrich: boa.ParamEnricherCombine(
+            boa.ParamEnricherName,
+            boa.ParamEnricherEnv,
+            boa.ParamEnricherBool,
+        ),
+        InitFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command) error {
+            // Descriptions / defaults / validation for the embedded fields come
+            // from the programmatic API since you can't tag them.
+            boa.GetParamT(ctx, &p.Host).SetDefaultT("localhost")
+            port := boa.GetParamT(ctx, &p.Port)
+            port.SetDefaultT(5432)
+            port.SetMinT(1)
+            port.SetMaxT(65535)
+            return nil
+        },
+        RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+            fmt.Printf("%s:%d\n", p.Host, p.Port)
+        },
+    }.Run()
+}
+```
+
+Now `app --config-file app.json` works, `--host` / `--port` / `$HOST` / `$PORT` work, and CLI still beats config-file — the full precedence chain is preserved because boa treats the embedded fields exactly like fields declared on the wrapper itself.
+
+### Variant B — inline anonymous struct
+
+If the wrapper is only used in a single `CmdT` call, you don't even need to name it. Declare it inline at the call site:
+
+```go
+boa.CmdT[struct {
+    externalpkg.Settings
+    ConfigFile string `configfile:"true" optional:"true"`
+}]{
+    Use: "app",
+    RunFunc: func(p *struct {
+        externalpkg.Settings
+        ConfigFile string `configfile:"true" optional:"true"`
+    }, cmd *cobra.Command, args []string) {
+        fmt.Printf("%s:%d\n", p.Host, p.Port)
+    },
+}.Run()
+```
+
+Same semantics as the named version — just fewer declarations. The tradeoff is that you have to repeat the anonymous type in each hook's signature (Go has no type-alias shortcut here), which gets noisy past one or two hooks. Fine for throwaway commands; for anything with `InitFuncCtx`, name the type.
+
+### Variant C — programmatic, no wrapper at all
+
+If the external struct already has the exact shape you want to expose, skip wrapping and configure the tagless struct directly. Add a `ConfigFile` field to a surrounding struct (or use the wrapper pattern above), then flip the flag from `InitFuncCtx`:
+
+```go
+type Params struct {
+    ConfigFile string `optional:"true" descr:"path to config file"`
+    externalpkg.Settings
+}
+
+boa.CmdT[Params]{
+    InitFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command) error {
+        // Equivalent to `configfile:"true"` on Params.ConfigFile, but set
+        // at runtime — useful when the surrounding struct comes from a
+        // package you don't want to add boa-specific tags to.
+        boa.GetParamT(ctx, &p.ConfigFile).SetConfigFile(true)
+        return nil
+    },
+    // ...
+}.Run()
+```
+
+`SetConfigFile(true)` is the programmatic equivalent of `configfile:"true"` — the field must still be a string, and the call must happen in `InitFunc` / `InitFuncCtx` (before boa builds the config-file registry). Calling it on a non-string field produces a clean user-input-style error, not a panic.
+
+### Caveats
+
+- **The embedded type must be exported** (`externalpkg.Settings`, not `externalpkg.settings`). Anonymous embedding of an unexported type produces an unexported field, which boa silently skips along with all of its children — CLI flags and env binding for those fields simply won't register. (Earlier versions panicked here; the current build skips cleanly.)
+- **Name collisions** between the wrapper's own fields and the embedded type's fields are resolved by Go's shallower-wins rule at the type level, but BOA registers flags by field name — so if both the wrapper and the embedded struct declare a `Name` field, boa will error on duplicate flag registration. Rename one, or switch to a named (non-anonymous) field, which auto-prefixes the embedded children and eliminates the collision.
+
 ## Limitations
 
-A handful of features are **not** currently available programmatically:
+A smaller handful of things are **not** currently available programmatically:
 
-- **`configfile:"true"` has no setter.** If you need auto-config-file loading pointed at a field inside an external struct, you'll need to add your own config-file param in a surrounding struct.
 - **`boa:"ignore"` at the tag level skips traversal entirely** so the mirror never exists; the programmatic equivalent `SetIgnored(true)` marks an existing mirror as ignored instead. The observable behavior is the same (no CLI, no env, no validation — only raw config-file unmarshal writes), but there's one subtle difference: with the tag, the field is not even walked, so deeply nested ignored sub-trees have zero cost at startup.
 - **`InitFuncCtx` only sees fields from the live params tree.** If the third-party struct contains its own nested pointer fields that start as `nil`, BOA preallocates them before `InitFuncCtx` runs (so you can take `&p.DB.Inner.Field` freely), but if the third-party code itself reassigns one of those pointers later, the mirror index may go stale — call into boa early in the lifecycle and let it own the tree.
 

--- a/pkg/boa/api_typed_param.go
+++ b/pkg/boa/api_typed_param.go
@@ -89,6 +89,14 @@ type ParamT[T any] interface {
 	// validation). Config-file unmarshal can still write to the field.
 	SetIgnored(ignored bool)
 
+	// SetConfigFile marks this string parameter as the auto-loaded config-file
+	// path for its enclosing struct. Mirrors `configfile:"true"`. The field
+	// must be a string; calling this on a non-string field is detected after
+	// hooks return and produces a user-input-style error. Must be called from
+	// InitFunc / InitFuncCtx so it takes effect before the config-file
+	// registry is built.
+	SetConfigFile(isConfigFile bool)
+
 	// SetDescription sets the help/description text for this parameter.
 	SetDescription(descr string)
 
@@ -276,6 +284,12 @@ func (w *ParamTView[T]) SetNoEnv(noEnv bool) {
 // SetIgnored fully excludes the parameter from boa processing.
 func (w *ParamTView[T]) SetIgnored(ignored bool) {
 	w.param.SetIgnored(ignored)
+}
+
+// SetConfigFile marks this string parameter as the auto-loaded config-file
+// path for its enclosing struct. Equivalent to the `configfile:"true"` tag.
+func (w *ParamTView[T]) SetConfigFile(isConfigFile bool) {
+	w.param.SetConfigFile(isConfigFile)
 }
 
 // SetDescription sets the help/description text.

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -192,6 +192,16 @@ type Param interface {
 	// cobra flag binding and env parsing.
 	SetIgnored(bool)
 
+	// IsConfigFile reports whether this string parameter is the auto-loaded
+	// config-file path for its enclosing struct. Mirrors `configfile:"true"`.
+	IsConfigFile() bool
+	// SetConfigFile marks the parameter as the config-file path for its
+	// enclosing struct. The underlying field must be a string. Must be
+	// called before cobra flag binding (i.e. from InitFunc / InitFuncCtx)
+	// to take effect — the configfile registry is built at the end of the
+	// init phase, right after these hooks run.
+	SetConfigFile(bool)
+
 	// GetDescription / SetDescription expose the help/descr text.
 	GetDescription() string
 	SetDescription(string)
@@ -1436,12 +1446,25 @@ func positionalSkipError(name, skipKind string) error {
 	return fmt.Errorf("param '%s': `boa:\"%s\"` cannot be combined with positional args — a positional arg is, by definition, a CLI arg", name, skipKind)
 }
 
-// isBoaIgnored reports whether a field is fully ignored by boa — no mirror,
-// no traversal. Only `boa:"ignore"` (aliases: `ignored`, `-`) triggers this.
+// isBoaIgnored reports whether a field should be skipped entirely by boa
+// traversal — no mirror, no preallocation, no CLI / env / config wiring.
+// Triggered by either:
+//   - `boa:"ignore"` (aliases: `ignored`, `-`) — explicit user opt-out, or
+//   - an unexported field — reflect cannot take the address of unexported
+//     fields without unsafe games, and by Go convention they are private
+//     implementation state owned by the declaring package. Embedding an
+//     unexported type (e.g. `type Wrapper struct { internalCfg }`) creates
+//     such a field; silently skipping it is friendlier than panicking deep
+//     in preallocateStructPtrs with `reflect.Value.Interface: cannot return
+//     value obtained from unexported field`.
+//
 // `boa:"configonly"` is deliberately NOT ignored: it produces a mirror and
 // runs validation, but is suppressed from CLI and env (see the enrichment
 // loop where it is translated to SetNoFlag+SetNoEnv).
 func isBoaIgnored(field reflect.StructField) bool {
+	if !field.IsExported() {
+		return true
+	}
 	boaTags := getBoaTags(field)
 	return slices.Contains(boaTags, "ignore") ||
 		slices.Contains(boaTags, "ignored") ||
@@ -1860,10 +1883,16 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				return positionalSkipError(param.GetName(), skipKind)
 			}
 
-			// Detect configfile tag
+			// Detect configfile — either from the tag or a programmatic
+			// SetConfigFile(true) call made during InitFunc / InitFuncCtx.
+			// The tag is normalized onto the flag first so downstream checks
+			// only need to read param.IsConfigFile().
 			if cfgTag, ok := tags.Lookup("configfile"); ok && cfgTag == "true" {
+				param.SetConfigFile(true)
+			}
+			if param.IsConfigFile() {
 				if param.GetType().Kind() != reflect.String {
-					return fmt.Errorf("configfile tag on param %s: must be a string field", param.GetName())
+					return fmt.Errorf("configfile on param %s: must be a string field", param.GetName())
 				}
 				// The target struct path is the parent of the configfile param's own path.
 				// Read it directly from paramMeta.pathKey (stashed during traverse) —

--- a/pkg/boa/param_meta.go
+++ b/pkg/boa/param_meta.go
@@ -90,6 +90,13 @@ type paramMeta struct {
 	// it desugars to noFlag+noEnv with the mirror preserved so validation
 	// and required checks still run.
 	ignored bool
+
+	// isConfigFile marks this string parameter as the config-file path for
+	// its parent struct. Mirrors `configfile:"true"`. When set, the field
+	// must be a string and its value (CLI / env / default) is used as a
+	// path to a config file that's unmarshaled into the enclosing struct.
+	// Set either via the tag or programmatically via SetConfigFile(true).
+	isConfigFile bool
 }
 
 var _ Param = &paramMeta{}
@@ -339,12 +346,14 @@ func (f *paramMeta) SetCustomValidator(validator func(any) error) {
 
 // --- noFlag / ignored ---
 
-func (f *paramMeta) IsNoFlag() bool      { return f.noFlag }
-func (f *paramMeta) SetNoFlag(val bool)  { f.noFlag = val }
-func (f *paramMeta) IsNoEnv() bool       { return f.noEnv }
-func (f *paramMeta) SetNoEnv(val bool)   { f.noEnv = val }
-func (f *paramMeta) IsIgnored() bool     { return f.ignored }
-func (f *paramMeta) SetIgnored(val bool) { f.ignored = val }
+func (f *paramMeta) IsNoFlag() bool         { return f.noFlag }
+func (f *paramMeta) SetNoFlag(val bool)     { f.noFlag = val }
+func (f *paramMeta) IsNoEnv() bool          { return f.noEnv }
+func (f *paramMeta) SetNoEnv(val bool)      { f.noEnv = val }
+func (f *paramMeta) IsIgnored() bool        { return f.ignored }
+func (f *paramMeta) SetIgnored(val bool)    { f.ignored = val }
+func (f *paramMeta) IsConfigFile() bool     { return f.isConfigFile }
+func (f *paramMeta) SetConfigFile(val bool) { f.isConfigFile = val }
 
 // --- min / max / pattern ---
 

--- a/pkg/boa/substruct_configfile_test.go
+++ b/pkg/boa/substruct_configfile_test.go
@@ -319,6 +319,250 @@ func TestSubStructConfigFile_CLIOverridesBothConfigs(t *testing.T) {
 	}
 }
 
+// ExternalDBConfig simulates a third-party struct we can't modify — no boa tags,
+// no `configfile:"true"` field. Users who want auto-config-file loading for such
+// a struct can wrap it via anonymous embedding and add their own configfile field.
+type ExternalDBConfig struct {
+	Host string
+	Port int
+}
+
+func TestEmbeddedExternalStruct_ConfigFileViaWrapper(t *testing.T) {
+	// Pattern: wrap an external struct via anonymous embedding and add a
+	// ConfigFile field with `configfile:"true"` in the wrapper. When the
+	// command loads the config file, JSON unmarshal flattens embedded fields
+	// to the top level, so the external struct's fields populate correctly —
+	// and the auto-generated CLI flags are un-prefixed (anonymous embed), so
+	// `--host` / `--port` still work without a namespace.
+	type Params struct {
+		ExternalDBConfig        // anonymous embed — no boa tags available
+		ConfigFile       string `configfile:"true" optional:"true" descr:"path to config file"`
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Host": "embedded-host",
+		"Port": 6543,
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotHost string
+	var gotPort int
+	err := (CmdT[Params]{
+		Use: "test",
+		ParamEnrich: ParamEnricherCombine(
+			ParamEnricherName,
+			ParamEnricherBool,
+		),
+		InitFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			// Descriptions / defaults for the external struct's fields come from
+			// the programmatic API since we can't add tags to ExternalDBConfig.
+			GetParamT(ctx, &p.Host).SetDefaultT("localhost")
+			GetParamT(ctx, &p.Port).SetDefaultT(5432)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+			gotPort = p.Port
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "embedded-host" {
+		t.Errorf("expected host='embedded-host' loaded from config, got %q", gotHost)
+	}
+	if gotPort != 6543 {
+		t.Errorf("expected port=6543 loaded from config, got %d", gotPort)
+	}
+}
+
+func TestEmbeddedExternalStruct_InlineWrapper(t *testing.T) {
+	// Ultra-lightweight variant: define the wrapper struct inline at the
+	// CmdT call site. No named type needed — the anonymous struct literal
+	// still carries the configfile tag on its own field and embeds the
+	// external struct, so it's the same pattern in one fewer declaration.
+	cfgData, _ := json.Marshal(map[string]any{
+		"Host": "inline-host",
+		"Port": 7777,
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotHost string
+	var gotPort int
+	err := (CmdT[struct {
+		ExternalDBConfig
+		ConfigFile string `configfile:"true" optional:"true"`
+	}]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, p *struct {
+			ExternalDBConfig
+			ConfigFile string `configfile:"true" optional:"true"`
+		}, cmd *cobra.Command) error {
+			GetParamT(ctx, &p.Host).SetDefaultT("localhost")
+			GetParamT(ctx, &p.Port).SetDefaultT(5432)
+			return nil
+		},
+		RunFunc: func(p *struct {
+			ExternalDBConfig
+			ConfigFile string `configfile:"true" optional:"true"`
+		}, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+			gotPort = p.Port
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "inline-host" {
+		t.Errorf("expected host='inline-host', got %q", gotHost)
+	}
+	if gotPort != 7777 {
+		t.Errorf("expected port=7777, got %d", gotPort)
+	}
+}
+
+func TestProgrammaticSetConfigFile(t *testing.T) {
+	// Verify SetConfigFile(true) from InitFuncCtx wires up auto-loading
+	// exactly like the `configfile:"true"` tag would. The field has NO
+	// configfile tag — only the programmatic call enables it.
+	type Params struct {
+		ConfigFile string `optional:"true" descr:"path to config"`
+		Host       string
+		Port       int
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{
+		"Host": "prog-host",
+		"Port": 4321,
+	})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotHost string
+	var gotPort int
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &p.ConfigFile).SetConfigFile(true)
+			GetParamT(ctx, &p.Host).SetDefaultT("localhost")
+			GetParamT(ctx, &p.Port).SetDefaultT(5432)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+			gotPort = p.Port
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "prog-host" {
+		t.Errorf("expected host='prog-host' loaded via programmatic SetConfigFile, got %q", gotHost)
+	}
+	if gotPort != 4321 {
+		t.Errorf("expected port=4321, got %d", gotPort)
+	}
+}
+
+func TestProgrammaticSetConfigFile_NonStringRejected(t *testing.T) {
+	// SetConfigFile on a non-string field should surface a clean error from
+	// the tag-processing pass rather than panicking.
+	type Params struct {
+		ConfigFile int
+		Host       string
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &p.ConfigFile).SetConfigFile(true)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{})
+
+	if err == nil {
+		t.Fatal("expected error for SetConfigFile on int field, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be a string field") {
+		t.Errorf("expected 'must be a string field' error, got %v", err)
+	}
+}
+
+func TestUnexportedFieldAutoSkipped(t *testing.T) {
+	// Unexported fields (including embedded unexported types) must be
+	// silently skipped by traversal, not crash preallocateStructPtrs with
+	// a reflect.Value.Interface panic. We can't use a real unexported
+	// embed in this test (the external type would need to be in the same
+	// package), but we can verify that declaring a struct with an
+	// unexported scalar field works without panicking.
+	type Params struct {
+		Host   string
+		secret string //nolint:unused // intentionally unexported to exercise the skip path
+	}
+
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFunc:     func(p *Params, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--host", "x"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEmbeddedExternalStruct_CLIOverridesConfigFile(t *testing.T) {
+	// Same wrapping pattern, but verify CLI precedence still works: a CLI flag
+	// on an embedded field should beat the value from the wrapper's configfile.
+	type Params struct {
+		ExternalDBConfig
+		ConfigFile string `configfile:"true" optional:"true"`
+	}
+
+	cfgData, _ := json.Marshal(map[string]any{"Host": "from-file", "Port": 1111})
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "app.json")
+	_ = os.WriteFile(cfgPath, cfgData, 0644)
+
+	var gotHost string
+	var gotPort int
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		InitFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			GetParamT(ctx, &p.Host).SetDefaultT("localhost")
+			GetParamT(ctx, &p.Port).SetDefaultT(5432)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			gotHost = p.Host
+			gotPort = p.Port
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath, "--host", "cli-wins"})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotHost != "cli-wins" {
+		t.Errorf("expected host='cli-wins' (CLI overrides configfile), got %q", gotHost)
+	}
+	if gotPort != 1111 {
+		t.Errorf("expected port=1111 (from configfile), got %d", gotPort)
+	}
+}
+
 func TestSubStructConfigFile_InnerOnly(t *testing.T) {
 	// Only inner config, no root config — should work fine
 	type DBConfig struct {


### PR DESCRIPTION
## Summary

- Adds `Param.SetConfigFile(bool)` / `ParamT[T].SetConfigFile(bool)` — the last struct-tag parity gap. `configfile:"true"` can now be enabled from `InitFunc` / `InitFuncCtx` for string fields inside third-party structs you can't tag. Non-string fields produce a clean user-input error instead of panicking.
- Documents and tests three ways to get auto-config-file loading pointed at an external struct: named wrapper (`type Wrapper struct { external.Config; ConfigFile string \`configfile:"true"\` }`), inline anonymous struct at the `CmdT` call site, and the fully programmatic variant via `SetConfigFile`.
- Side-fix: traversal silently skips unexported struct fields instead of crashing in `preallocateStructPtrs` with `reflect.Value.Interface: cannot return value obtained from unexported field`. Embedding an unexported external type is now a no-op rather than a panic.

## Test plan

- [x] `go test ./...` — all packages green
- [x] New tests cover: embed + root `configfile` tag, embed + CLI override, inline anonymous-struct wrapper, programmatic `SetConfigFile` on an untagged string field, `SetConfigFile` on non-string rejected, unexported field auto-skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added programmatic API method for enabling config-file auto-loading on string fields, equivalent to the struct tag.
  * Extended documentation covering multiple approaches to enable automatic config-file loading for external structs.

* **Bug Fixes**
  * Non-string config-file fields now produce a clean user error instead of a panic.
  * Unexported struct fields are properly ignored during processing.

* **Documentation**
  * Updated API mapping documentation and removed limitations regarding config-file programmatic support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->