### PR TITLE
feat: add LoadConfigBytes for in-memory config sources

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -316,6 +316,26 @@ boa.CmdT[Params]{
 }.Run()
 ```
 
+### Loading Config From In-Memory Bytes
+
+When the config lives somewhere other than a local file — an embedded `//go:embed` asset, stdin, an HTTP response, a secrets-manager blob, or a test fixture — use `boa.LoadConfigBytes`. It shares `LoadConfigFile`'s format-resolution rules (overrides → registered format for `ext` → JSON fallback), so any format registered via `RegisterConfigFormat` works identically.
+
+```go
+//go:embed defaults.yaml
+var defaultsYAML []byte
+
+boa.CmdT[Params]{
+    Use: "app",
+    PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+        // Seed defaults from the embedded YAML blob.
+        // CLI and env vars still override whatever is loaded here.
+        return boa.LoadConfigBytes(defaultsYAML, ".yaml", p, nil)
+    },
+}.Run()
+```
+
+`ext` accepts `".yaml"`, `"yaml"`, or `""` (empty falls back to JSON). Empty or `nil` `data` is a no-op, so callers can hand in the result of an optional read without a preceding length check.
+
 ## Checking Value Sources
 
 Use `HookContext` in your run function to check how values were set:

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -653,6 +653,65 @@ func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte
 - `target`: pointer to the struct to populate
 - `unmarshalFunc`: custom unmarshal function (`nil` uses file extension detection, then falls back to `json.Unmarshal`)
 
+## Loading Config From Bytes
+
+When the config does not live on disk — for example, `//go:embed` assets, stdin, an HTTP response body, or a test fixture — use `boa.LoadConfigBytes`. It shares the same format-resolution rules as `LoadConfigFile`, so registered formats like YAML or TOML work exactly the same.
+
+```go
+package main
+
+import (
+    _ "embed"
+    "fmt"
+
+    "github.com/GiGurra/boa/pkg/boa"
+    "github.com/spf13/cobra"
+    "gopkg.in/yaml.v3"
+)
+
+//go:embed defaults.yaml
+var defaultsYAML []byte
+
+type Params struct {
+    Host string `optional:"true"`
+    Port int    `optional:"true"`
+}
+
+func main() {
+    boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+
+    boa.CmdT[Params]{
+        Use: "app",
+        PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+            // Seed defaults from the embedded YAML blob. CLI and env vars
+            // still win over whatever is loaded here.
+            return boa.LoadConfigBytes(defaultsYAML, ".yaml", p, nil)
+        },
+        RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+            fmt.Printf("Host=%s Port=%d\n", p.Host, p.Port)
+        },
+    }.Run()
+}
+```
+
+`LoadConfigBytes` signature:
+
+```go
+func LoadConfigBytes[T any](data []byte, ext string, target *T, unmarshalFunc func([]byte, any) error) error
+```
+
+- `data`: the raw config bytes (empty or `nil` is a no-op)
+- `ext`: file extension used to pick a registered format — `".yaml"`, `"yaml"`, or `""` (empty falls back to JSON). The leading dot is optional.
+- `target`: pointer to the struct to populate
+- `unmarshalFunc`: custom unmarshal function — when non-nil, takes precedence over `ext`
+
+Typical sources:
+
+- `//go:embed` — ship a default config file inside the binary
+- Piped stdin — `data, _ := io.ReadAll(os.Stdin)`
+- HTTP / S3 / secrets manager responses — treat the response body as config bytes
+- In-memory test fixtures — no temp files required
+
 ## Mixed Config Formats
 
 Different config files can use different formats. The format is detected by file extension when using the registry.

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -514,6 +514,36 @@ func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte
 	return err
 }
 
+// LoadConfigBytes unmarshals raw config bytes into the target struct, using
+// the same format-resolution rules as LoadConfigFile. This is the in-memory
+// counterpart for cases where the bytes do not come from a local file —
+// typical callers are //go:embed assets, stdin pipes, HTTP response bodies,
+// and test fixtures.
+//
+// ext selects the registered format (e.g. ".yaml", ".toml"). A leading dot is
+// optional — "yaml" and ".yaml" both work. Pass "" to use the default JSON
+// parser. If unmarshalFunc is non-nil it takes precedence over ext.
+//
+// Passing an empty data slice is a no-op (returns nil) so callers can hand in
+// the result of an optional read without a preceding len check.
+//
+// CLI and env var values still take precedence when this is used inside
+// PreValidateFunc, exactly as with LoadConfigFile.
+func LoadConfigBytes[T any](data []byte, ext string, target *T, unmarshalFunc func([]byte, any) error) error {
+	if len(data) == 0 {
+		return nil
+	}
+	override := ConfigFormat{}
+	if unmarshalFunc != nil {
+		override.Unmarshal = unmarshalFunc
+	}
+	if ext != "" && !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+	_, err := loadConfigBytesInto(data, ext, target, override)
+	return err
+}
+
 // ConfigFormat describes how to parse and introspect a config file format.
 //
 // boa ships with a built-in handler for JSON only. To support other formats
@@ -731,26 +761,40 @@ func loadConfigFileInto(filePath string, target any, override ConfigFormat) ([]b
 	if err != nil {
 		return nil, ConfigFormat{}, fmt.Errorf("failed to read config file %s: %w", filePath, err)
 	}
-	effective := resolveConfigFormat(filePath, override)
-	if err := effective.Unmarshal(fileContents, target); err != nil {
+	effective, err := loadConfigBytesInto(fileContents, filepath.Ext(filePath), target, override)
+	if err != nil {
 		return nil, effective, fmt.Errorf("failed to unmarshal config file %s: %w", filePath, err)
 	}
 	return fileContents, effective, nil
 }
 
-// resolveConfigFormat picks the ConfigFormat to use for a given file, honouring
-// the precedence override → extension-registered → JSON fallback. The returned
-// ConfigFormat always has a non-nil Unmarshal.
-func resolveConfigFormat(filePath string, override ConfigFormat) ConfigFormat {
+// loadConfigBytesInto is the shared bytes-level core used by both file and
+// in-memory loaders. It resolves the effective ConfigFormat the same way as
+// loadConfigFileInto and runs the unmarshaler against the supplied bytes.
+func loadConfigBytesInto(data []byte, ext string, target any, override ConfigFormat) (ConfigFormat, error) {
+	effective := resolveConfigFormatByExt(ext, override)
+	if err := effective.Unmarshal(data, target); err != nil {
+		return effective, err
+	}
+	return effective, nil
+}
+
+// resolveConfigFormatByExt picks the ConfigFormat to use for a given extension,
+// honouring the precedence override → extension-registered → JSON fallback.
+// The returned ConfigFormat always has a non-nil Unmarshal. ext should be
+// dot-prefixed (filepath.Ext form); an empty string means "no hint" and falls
+// through to the JSON default.
+func resolveConfigFormatByExt(ext string, override ConfigFormat) ConfigFormat {
 	if override.Unmarshal != nil {
 		return override
 	}
-	ext := filepath.Ext(filePath)
-	configFormatsMu.RLock()
-	cf, ok := configFormats[ext]
-	configFormatsMu.RUnlock()
-	if ok && cf.Unmarshal != nil {
-		return cf
+	if ext != "" {
+		configFormatsMu.RLock()
+		cf, ok := configFormats[ext]
+		configFormatsMu.RUnlock()
+		if ok && cf.Unmarshal != nil {
+			return cf
+		}
 	}
 	return ConfigFormat{Unmarshal: json.Unmarshal, KeyTree: jsonKeyTree}
 }

--- a/pkg/boa/config_file_test.go
+++ b/pkg/boa/config_file_test.go
@@ -317,3 +317,152 @@ func TestConfigFile_TagShorthand(t *testing.T) {
 		}
 	})
 }
+
+// --- Tests for LoadConfigBytes ---
+
+func TestLoadConfigBytes(t *testing.T) {
+	type Params struct {
+		Host string `optional:"true"`
+		Port int    `optional:"true"`
+	}
+
+	t.Run("loads JSON bytes with default format", func(t *testing.T) {
+		var p Params
+		if err := LoadConfigBytes([]byte(`{"Host":"h","Port":1234}`), "", &p, nil); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if p.Host != "h" || p.Port != 1234 {
+			t.Errorf("unexpected parsed values: %+v", p)
+		}
+	})
+
+	t.Run("loads JSON bytes with explicit .json ext", func(t *testing.T) {
+		var p Params
+		if err := LoadConfigBytes([]byte(`{"Host":"h"}`), ".json", &p, nil); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if p.Host != "h" {
+			t.Errorf("expected Host=h, got %q", p.Host)
+		}
+	})
+
+	t.Run("normalizes ext without leading dot", func(t *testing.T) {
+		var p Params
+		if err := LoadConfigBytes([]byte(`{"Host":"h"}`), "json", &p, nil); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if p.Host != "h" {
+			t.Errorf("expected Host=h, got %q", p.Host)
+		}
+	})
+
+	t.Run("dispatches to registered format by extension", func(t *testing.T) {
+		registerFormatCleanup(t, ".fake", UniversalConfigFormat(fakeUnmarshal))
+
+		var p Params
+		if err := LoadConfigBytes([]byte(`{"Host":"from-fake","Port":9}`), ".fake", &p, nil); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if p.Host != "from-fake" || p.Port != 9 {
+			t.Errorf("unexpected parsed values: %+v", p)
+		}
+	})
+
+	t.Run("unmarshalFunc overrides ext", func(t *testing.T) {
+		called := false
+		custom := func(data []byte, target any) error {
+			called = true
+			return json.Unmarshal(data, target)
+		}
+		var p Params
+		if err := LoadConfigBytes([]byte(`{"Host":"x"}`), ".yaml", &p, custom); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if !called {
+			t.Error("expected custom unmarshal func to be called")
+		}
+		if p.Host != "x" {
+			t.Errorf("expected Host=x, got %q", p.Host)
+		}
+	})
+
+	t.Run("empty bytes is a no-op", func(t *testing.T) {
+		var p Params
+		if err := LoadConfigBytes(nil, "", &p, nil); err != nil {
+			t.Fatalf("nil: %v", err)
+		}
+		if err := LoadConfigBytes([]byte{}, "", &p, nil); err != nil {
+			t.Fatalf("empty: %v", err)
+		}
+		if p.Host != "" || p.Port != 0 {
+			t.Errorf("expected zero params, got %+v", p)
+		}
+	})
+
+	t.Run("malformed bytes return error", func(t *testing.T) {
+		var p Params
+		err := LoadConfigBytes([]byte(`{not json`), "", &p, nil)
+		if err == nil {
+			t.Fatal("expected error for malformed bytes")
+		}
+	})
+
+	t.Run("works inside PreValidateFunc with embed-like input", func(t *testing.T) {
+		// Simulates //go:embed or stdin pipes feeding bytes into a hook.
+		type CmdParams struct {
+			Host string `optional:"true"`
+			Port int    `optional:"true"`
+		}
+		embedded := []byte(`{"Host":"embedded","Port":4242}`)
+
+		ran := false
+		CmdT[CmdParams]{
+			Use: "test",
+			PreValidateFunc: func(params *CmdParams, cmd *cobra.Command, args []string) error {
+				return LoadConfigBytes(embedded, ".json", params, nil)
+			},
+			RunFunc: func(params *CmdParams, cmd *cobra.Command, args []string) {
+				ran = true
+				if params.Host != "embedded" {
+					t.Errorf("expected Host='embedded', got %q", params.Host)
+				}
+				if params.Port != 4242 {
+					t.Errorf("expected Port=4242, got %d", params.Port)
+				}
+			},
+		}.RunArgs([]string{})
+
+		if !ran {
+			t.Fatal("command did not run")
+		}
+	})
+
+	t.Run("CLI overrides bytes config in PreValidateFunc", func(t *testing.T) {
+		type CmdParams struct {
+			Host string `optional:"true"`
+			Port int    `optional:"true"`
+		}
+		embedded := []byte(`{"Host":"from-bytes","Port":3000}`)
+
+		ran := false
+		CmdT[CmdParams]{
+			Use: "test",
+			PreValidateFunc: func(params *CmdParams, cmd *cobra.Command, args []string) error {
+				return LoadConfigBytes(embedded, "", params, nil)
+			},
+			RunFunc: func(params *CmdParams, cmd *cobra.Command, args []string) {
+				ran = true
+				if params.Host != "from-cli" {
+					t.Errorf("expected Host='from-cli' (CLI wins), got %q", params.Host)
+				}
+				if params.Port != 3000 {
+					t.Errorf("expected Port=3000 (from bytes), got %d", params.Port)
+				}
+			},
+		}.RunArgs([]string{"--host", "from-cli"})
+
+		if !ran {
+			t.Fatal("command did not run")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `boa.LoadConfigBytes(data, ext, target, unmarshalFunc)` — a bytes-level counterpart to `LoadConfigFile` for `//go:embed` assets, stdin pipes, HTTP responses, secrets-manager blobs, and in-memory test fixtures.
- Refactors the internal format-resolution path so `LoadConfigFile` and `LoadConfigBytes` share one bytes-level core (`loadConfigBytesInto` + `resolveConfigFormatByExt`). No behavior change for existing callers.
- Extends docs (`docs/examples-config.md`, `docs/advanced.md`) with an embed-based example and the new API signature.

`ext` accepts `".yaml"`, `"yaml"`, or `""` (empty → JSON fallback). Empty / nil `data` is a no-op so callers can hand in the result of an optional read without a length check. When `unmarshalFunc` is non-nil it takes precedence over `ext`, mirroring `LoadConfigFile`.

This closes the "reading config from io.Reader / already-loaded bytes" gap versus Viper, without pulling in an io.Reader dep in the surface API.

## Test plan
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] New `TestLoadConfigBytes` covers: default JSON, explicit `.json`, ext normalization (`json` → `.json`), registered-format dispatch, `unmarshalFunc` override, nil/empty no-op, malformed bytes error path, inside `PreValidateFunc`, CLI precedence over bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `LoadConfigBytes` API for loading configuration from in-memory byte sources (e.g., embedded files, stdin, HTTP responses, test fixtures). Supports the same format-resolution and override behavior as file-based configuration loading.

* **Documentation**
  * Added comprehensive documentation and runnable examples for the new in-memory configuration loading functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->