### PR TITLE
feat: add DumpConfig + source-aware HookContext dump

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -336,6 +336,26 @@ boa.CmdT[Params]{
 
 `ext` accepts `".yaml"`, `"yaml"`, or `""` (empty falls back to JSON). Empty or `nil` `data` is a no-op, so callers can hand in the result of an optional read without a preceding length check.
 
+### Writing Resolved Config Back Out
+
+Two serializers are available for the other direction:
+
+- `boa.DumpConfigBytes(v, ext, nil)` / `boa.DumpConfigFile(path, v, nil)` — naive dump, emits every exported field including Go zero values. Good for "generate an example config that shows every option".
+- `ctx.DumpBytes(ext, nil)` / `ctx.DumpFile(path, nil)` on `HookContext` — **source-aware**, emits only fields where `HasValue` is true (CLI, env, config file, default). Fields the user never touched are omitted entirely. This is the right helper for persisting resolved config between runs.
+
+Source-aware dump pins defaults into the file, which is deliberate: a future release can change the app's built-in defaults without silently changing behavior for users whose saved config said "I'm happy with what shipped in version 1.0". The `configfile` path parameter itself is omitted so the dumped file doesn't reference its own path on the next load.
+
+Key names honour format-appropriate struct tags (`json:"..."` for `.json`, `yaml:"..."` for `.yaml`/`.yml`, `toml:"..."` for `.toml`, `hcl:"..."` for `.hcl`); untagged fields fall back to Go field names. `json:"-"` skips the field entirely.
+
+Non-JSON formats need a marshaler registered alongside the unmarshaler:
+
+```go
+boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
+```
+
+JSON comes with both directions pre-registered (pretty-printed, 2-space indent, trailing newline). See [examples-config.md](examples-config.md#writing-config-back-out) for full examples.
+
 ## Checking Value Sources
 
 Use `HookContext` in your run function to check how values were set:

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -712,6 +712,89 @@ Typical sources:
 - HTTP / S3 / secrets manager responses — treat the response body as config bytes
 - In-memory test fixtures — no temp files required
 
+## Writing Config Back Out
+
+BOA can also serialize a resolved parameter set back out to a config file. Two variants are provided:
+
+| API | When to use |
+|-----|-------------|
+| `boa.DumpConfigBytes(v, ext, nil)` / `boa.DumpConfigFile(path, v, nil)` | **Naive dump.** Emits every exported field on `v`, including Go zero values. Good for "generate an example config that shows every option". |
+| `ctx.DumpBytes(ext, nil)` / `ctx.DumpFile(path, nil)` (on `HookContext`) | **Source-aware dump.** Emits only fields that have a value from CLI, environment, config file, or a default — fields the user never touched are omitted entirely. This is the right helper for persisting resolved config between runs. |
+
+Source-aware dump is the useful one for most production apps: because defaults count as "set", the dumped file pins the current default values in place, so a future release that ships different built-in defaults won't silently change behavior for users whose saved config said "I'm happy with what you shipped in version 1.0".
+
+```go
+package main
+
+import (
+    "github.com/GiGurra/boa/pkg/boa"
+    "github.com/spf13/cobra"
+    "gopkg.in/yaml.v3"
+)
+
+type Params struct {
+    Name    string `optional:"true"`
+    Host    string `optional:"true" default:"localhost"`
+    Port    int    `optional:"true" default:"8080"`
+    Verbose bool   `optional:"true"`
+}
+
+func main() {
+    boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+    boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
+
+    boa.CmdT[Params]{
+        Use: "app",
+        RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+            // Persist the resolved config so the next run reuses it.
+            // CLI-set values, env-set values, config-file values, and
+            // defaults all get written out. Fields the user never
+            // touched stay omitted.
+            if err := ctx.DumpFile("~/.myapp/config.yaml", nil); err != nil {
+                // ...
+            }
+        },
+    }.Run()
+}
+```
+
+API signatures:
+
+```go
+// Naive — whole struct, zero values and all.
+func DumpConfigBytes[T any](v *T, ext string, marshalFunc func(v any) ([]byte, error)) ([]byte, error)
+func DumpConfigFile[T any](filePath string, v *T, marshalFunc func(v any) ([]byte, error)) error
+
+// Source-aware — only fields with HasValue=true.
+func (c *HookContext) DumpBytes(ext string, marshalFunc func(v any) ([]byte, error)) ([]byte, error)
+func (c *HookContext) DumpFile(filePath string, marshalFunc func(v any) ([]byte, error)) error
+```
+
+### Enabling dump for non-JSON formats
+
+`RegisterConfigFormat` only installs an unmarshaler. To also enable `Dump*`, pair it with `RegisterConfigMarshaler`:
+
+```go
+boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
+```
+
+JSON comes with both directions pre-registered, indented with two spaces and terminated with a trailing newline.
+
+If you try to dump to a format with no registered marshaler, `Dump*` returns a clear error rather than silently falling through to JSON — writing JSON bytes to a file named `.yaml` would be a nasty surprise.
+
+### What gets omitted from a source-aware dump
+
+- **Unset fields** — fields where nothing (CLI, env, config, inject, default) has ever supplied a value. `Silent bool` without a default stays out of the dump rather than appearing as `"Silent": false` for every user who never touched it.
+- **The `configfile` field** — the path to the config file itself is never written into the dumped file, because a config file that references its own path is self-referential and surprising on the next load.
+- **Nested structs with no set descendants** — if nothing in `DB` is set, the whole `DB` key is omitted (not emitted as an empty object).
+- **Nil optional struct-pointer groups** (`DB *DBConfig`) — same as the above.
+
+### What gets kept
+
+- **CLI / env / config / inject values** — always.
+- **Defaults** — always, to pin them against future app upgrades that might change them. The one exception is bool fields whose only claim to "set" is the auto-installed `false` default from `ParamEnricherBool`; those are treated as unset unless the user explicitly flipped them.
+
 ## Mixed Config Formats
 
 Different config files can use different formats. The format is detected by file extension when using the registry.

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -482,6 +482,264 @@ func (c *HookContext) HasValue(fieldPtr any) bool {
 	return HasValue(param)
 }
 
+// DumpBytes serializes the parameters associated with this HookContext to
+// config bytes, emitting only fields where HasValue reports true. That is:
+// any field set via CLI, environment, config file, or a struct-tag / hook
+// default is written out; fields that were never set are omitted entirely.
+//
+// This is the right helper for persisting resolved config between runs:
+// because defaults count as "set", the dump pins the current default values
+// into the file, so the next run sees the same config even if a future
+// release changes the app's built-in defaults. Truly-unset fields stay
+// omitted, so the output doesn't fill up with Go zero values (0, "", false,
+// nil) for options the user never touched.
+//
+// ext selects the registered format (e.g. ".yaml", ".toml"). A leading dot
+// is optional. Pass "" for pretty-printed JSON. If marshalFunc is non-nil
+// it takes precedence over ext. Same format-resolution rules and error
+// behaviour as DumpConfigBytes.
+//
+// Key names are taken from the output format's struct tag when present:
+//
+//   - .json output honours `json:"name"` tags
+//   - .yaml / .yml output honours `yaml:"name"` tags
+//   - .toml output honours `toml:"name"` tags
+//
+// Fields with a `-` tag for the output format are skipped entirely. When no
+// tag is set, the Go struct field name is used verbatim — matching what
+// standard marshalers do when you hand them the original struct. This makes
+// source-aware dumps round-trip cleanly through LoadConfig* for structs
+// that mix format-specific tags with untagged fields.
+//
+// The configfile param itself (the field tagged configfile:"true") is
+// omitted from the output — a dumped file that references its own path as
+// a field is self-referential and surprising on the next load.
+func (c *HookContext) DumpBytes(ext string, marshalFunc func(v any) ([]byte, error)) ([]byte, error) {
+	if ext != "" && !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+	tree, err := c.buildSetValueTree(structTagForExt(ext))
+	if err != nil {
+		return nil, err
+	}
+	marshal, err := resolveConfigMarshalByExt(ext, marshalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return marshal(tree)
+}
+
+// structTagForExt maps a config file extension to the struct tag the
+// corresponding marshaler consults when encoding struct values. We use the
+// same tag for the map[string]any key names so a source-aware dump's output
+// uses the same names as if the marshaler had handled the struct itself.
+// An empty return value means "no tag lookup — use the Go field name".
+func structTagForExt(ext string) string {
+	switch ext {
+	case ".json", "":
+		return "json"
+	case ".yaml", ".yml":
+		return "yaml"
+	case ".toml":
+		return "toml"
+	case ".hcl":
+		return "hcl"
+	}
+	return ""
+}
+
+// resolveDumpFieldName picks the key name for a struct field in a
+// source-aware dump. It honours the format-appropriate struct tag so
+// `Host string `json:"hostname"`` dumps as `"hostname"` (and round-trips
+// through LoadConfigFile). A "-" tag value means "skip this field";
+// callers should drop the field entirely when this returns ("", true).
+// An empty tagName means "no tag lookup"; fall back to the field name.
+func resolveDumpFieldName(sf reflect.StructField, tagName string) (name string, skip bool) {
+	if tagName == "" {
+		return sf.Name, false
+	}
+	tag := sf.Tag.Get(tagName)
+	if tag == "" {
+		return sf.Name, false
+	}
+	// Tag value may be `name,opt1,opt2` (e.g. json:"name,omitempty").
+	// We only care about the name part.
+	if comma := strings.IndexByte(tag, ','); comma >= 0 {
+		tag = tag[:comma]
+	}
+	if tag == "-" {
+		return "", true
+	}
+	if tag == "" {
+		return sf.Name, false
+	}
+	return tag, false
+}
+
+// DumpFile is the file-writing counterpart to DumpBytes. The marshaler is
+// resolved from filePath's extension; the file is written with mode 0644
+// and overwrites any existing file.
+func (c *HookContext) DumpFile(filePath string, marshalFunc func(v any) ([]byte, error)) error {
+	if filePath == "" {
+		return NewUserInputError(fmt.Errorf("HookContext.DumpFile: filePath must not be empty"))
+	}
+	data, err := c.DumpBytes(filepath.Ext(filePath), marshalFunc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for %s: %w", filePath, err)
+	}
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config file %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// buildSetValueTree walks the root parameters struct and returns a nested
+// map[string]any containing only fields where the corresponding param
+// mirror's HasValue() is true. Nested structs appear as nested maps and are
+// omitted entirely when they have no set descendants.
+//
+// tagName picks the struct tag used for map key names (see
+// structTagForExt). An empty tagName falls back to the Go field name.
+func (c *HookContext) buildSetValueTree(tagName string) (map[string]any, error) {
+	if c == nil || c.ctx == nil {
+		return nil, fmt.Errorf("boa: HookContext: uninitialized (no parameters registered)")
+	}
+	if c.ctx.rootStructPtr == nil {
+		return nil, fmt.Errorf("boa: HookContext: no root parameters struct")
+	}
+	rv := reflect.ValueOf(c.ctx.rootStructPtr)
+	if rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil, fmt.Errorf("boa: HookContext: root parameters struct is nil")
+		}
+		rv = rv.Elem()
+	}
+	return buildSetValueMapNode(rv, c.ctx, nil, tagName), nil
+}
+
+// shouldEmitInDump decides whether a leaf parameter should appear in a
+// source-aware config dump. The rule is HasValue with one deliberate
+// exception for bools:
+//
+// ParamEnricherBool auto-installs a `false` default for every bool
+// parameter that does not specify one, so a plain `Silent bool` field
+// would otherwise always satisfy HasValue even when the user never touched
+// it. For dump purposes we treat a bool that is still sitting at the
+// default-false value as unset unless CLI / env / config / inject says
+// otherwise — otherwise every dump fills up with `"Silent": false`
+// noise for flags the user never flipped.
+//
+// Trade-off: a user who explicitly writes `default:"false"` on a bool in a
+// struct tag will see the same omission, since the enricher's default and
+// a hand-written `false` default are indistinguishable. Users who want the
+// explicit emission can run with --their-flag=false once; the source
+// tracking then records wasSetOnCli and the dump emits it.
+func shouldEmitInDump(f Param, v reflect.Value) bool {
+	if f.wasSetOnCli() || f.wasSetByEnv() || f.wasSetByInject() {
+		return true
+	}
+	if pm, ok := f.(*paramMeta); ok && pm.setByConfig {
+		return true
+	}
+	if !f.hasDefaultValue() {
+		return false
+	}
+	if f.GetKind() == reflect.Bool {
+		if b, ok := v.Interface().(bool); ok && !b {
+			return false
+		}
+	}
+	return true
+}
+
+// buildSetValueMapNode is the recursive walker used by buildSetValueTree.
+// It returns nil when the entire subtree has no set fields so the caller
+// can omit the parent key. tagName is the struct tag to consult for field
+// key names (see structTagForExt); an empty tagName means "use the Go
+// field name".
+func buildSetValueMapNode(v reflect.Value, ctx *processingContext, pathIdx []int, tagName string) map[string]any {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	t := v.Type()
+	out := map[string]any{}
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		fv := v.Field(i)
+		childIdx := append(append([]int{}, pathIdx...), i)
+		pathKey := joinPath(childIdx)
+
+		if mirror, ok := ctx.mirrorByPath[pathKey]; ok {
+			// Leaf parameter with a registered mirror.
+			if mirror.IsConfigFile() {
+				// Never write the configfile path back into the dumped file —
+				// self-reference on the next load is a surprise.
+				continue
+			}
+			if shouldEmitInDump(mirror, fv) {
+				name, skip := resolveDumpFieldName(sf, tagName)
+				if skip {
+					continue
+				}
+				out[name] = fv.Interface()
+			}
+			continue
+		}
+		// No direct mirror at this path → might be a nested anonymous or
+		// pointer struct whose children carry the mirrors. Recurse.
+		// Anonymous (embedded) fields flatten their children into the
+		// parent map, matching boa's flag-generation semantics (an embedded
+		// DBConfig produces --host, not --db-config-host) and encoding/json's
+		// default struct-embedding flattening.
+		switch fv.Kind() {
+		case reflect.Struct:
+			if sub := buildSetValueMapNode(fv, ctx, childIdx, tagName); len(sub) > 0 {
+				if sf.Anonymous {
+					for k, v := range sub {
+						out[k] = v
+					}
+				} else {
+					name, skip := resolveDumpFieldName(sf, tagName)
+					if skip {
+						continue
+					}
+					out[name] = sub
+				}
+			}
+		case reflect.Ptr:
+			if !fv.IsNil() && fv.Elem().Kind() == reflect.Struct {
+				if sub := buildSetValueMapNode(fv, ctx, childIdx, tagName); len(sub) > 0 {
+					if sf.Anonymous {
+						for k, v := range sub {
+							out[k] = v
+						}
+					} else {
+						name, skip := resolveDumpFieldName(sf, tagName)
+						if skip {
+							continue
+						}
+						out[name] = sub
+					}
+				}
+			}
+		}
+		// Other kinds with no mirror → boa:"ignore" or unsupported; skip.
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // CmdList converts a list of CmdIfc to a slice of cobra.Command.
 func CmdList(cmds ...CmdIfc) []*cobra.Command {
 	var cobraCmds []*cobra.Command
@@ -544,6 +802,64 @@ func LoadConfigBytes[T any](data []byte, ext string, target *T, unmarshalFunc fu
 	return err
 }
 
+// DumpConfigBytes serializes v to config bytes using the marshaler resolved
+// from ext. This is the *naive* dump — every exported field on v is emitted,
+// including Go zero values. Useful for "generate an example config with
+// every option" or round-trip tests.
+//
+// For "persist the resolved config between runs, but don't emit fields the
+// user never set" semantics, use HookContext.DumpBytes / HookContext.DumpFile
+// instead — those honour HasValue so unset fields are omitted entirely and
+// defaults are still pinned in place across app upgrades.
+//
+// ext selects the registered format (e.g. ".yaml", ".toml"). A leading dot
+// is optional. Pass "" to use the default pretty-printed JSON marshaler.
+// If marshalFunc is non-nil it takes precedence over ext.
+//
+// Unlike LoadConfigBytes, there is no silent cross-format fallback: if the
+// requested extension is registered but has no Marshal, DumpConfigBytes
+// returns a clear error pointing at RegisterConfigMarshaler. Writing JSON
+// bytes to a file named `.yaml` would be a nasty surprise, so the API
+// refuses rather than guessing.
+//
+// The JSON default is indented with two spaces and ends with a trailing
+// newline — the shape you'd expect when the bytes are about to land on disk.
+func DumpConfigBytes[T any](v *T, ext string, marshalFunc func(v any) ([]byte, error)) ([]byte, error) {
+	if ext != "" && !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
+	marshal, err := resolveConfigMarshalByExt(ext, marshalFunc)
+	if err != nil {
+		return nil, err
+	}
+	return marshal(v)
+}
+
+// DumpConfigFile serializes v and writes it to filePath. The marshaler is
+// resolved from the file extension using the same rules as DumpConfigBytes.
+// The file is written with mode 0644; if a file already exists at filePath
+// it is overwritten.
+//
+// Pass a non-nil marshalFunc to override the extension-registered marshaler
+// (mirrors LoadConfigFile's unmarshalFunc parameter).
+//
+// If filePath is empty, returns a clear user-input error — unlike
+// LoadConfigFile, there is no "empty is a no-op" shortcut, because silently
+// dropping a dump request is more surprising than a missing load.
+func DumpConfigFile[T any](filePath string, v *T, marshalFunc func(v any) ([]byte, error)) error {
+	if filePath == "" {
+		return NewUserInputError(fmt.Errorf("DumpConfigFile: filePath must not be empty"))
+	}
+	data, err := DumpConfigBytes(v, filepath.Ext(filePath), marshalFunc)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for %s: %w", filePath, err)
+	}
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config file %s: %w", filePath, err)
+	}
+	return nil
+}
+
 // ConfigFormat describes how to parse and introspect a config file format.
 //
 // boa ships with a built-in handler for JSON only. To support other formats
@@ -551,8 +867,19 @@ func LoadConfigBytes[T any](data []byte, ext string, target *T, unmarshalFunc fu
 // bring your own parser and register it via RegisterConfigFormatFull — or set
 // Cmd.ConfigFormat on a single command.
 type ConfigFormat struct {
-	// Unmarshal parses raw bytes into the target struct. Required.
+	// Unmarshal parses raw bytes into the target struct. Required for
+	// LoadConfigFile / LoadConfigBytes. A ConfigFormat with a nil Unmarshal
+	// is "dump-only" — it can still be used by DumpConfigFile /
+	// DumpConfigBytes if Marshal is set, but reading will fall through to
+	// the JSON fallback.
 	Unmarshal func(data []byte, target any) error
+
+	// Marshal serializes a value back out to raw bytes. Optional — only
+	// required for DumpConfigFile / DumpConfigBytes. Callers that ask to
+	// dump a format that has no registered Marshal get a clear error
+	// instead of a silent cross-format fallback, because (for example)
+	// writing JSON bytes to a file named `.yaml` would be a nasty surprise.
+	Marshal func(v any) ([]byte, error)
 
 	// KeyTree returns a nested map[string]any representing the top-level and
 	// nested key structure of the raw bytes. boa uses this to detect which
@@ -583,6 +910,7 @@ var (
 	configFormats   = map[string]ConfigFormat{
 		".json": {
 			Unmarshal: json.Unmarshal,
+			Marshal:   jsonMarshalPretty,
 			KeyTree:   jsonKeyTree,
 		},
 	}
@@ -595,6 +923,19 @@ func jsonKeyTree(data []byte) (map[string]any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// jsonMarshalPretty is the built-in Marshal used for DumpConfig*.
+// It produces human-readable, 2-space-indented JSON with a trailing
+// newline — the shape you'd expect when writing a config file to disk.
+// json.Marshal's compact output round-trips fine but is unfriendly for a
+// human who opens the file after a dump.
+func jsonMarshalPretty(v any) ([]byte, error) {
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
 }
 
 // UniversalConfigFormat builds a ConfigFormat from a single "universal"
@@ -711,6 +1052,31 @@ func RegisterConfigFormatFull(ext string, format ConfigFormat) {
 	configFormats[normalized] = format
 }
 
+// RegisterConfigMarshaler attaches a Marshal function to a registered format,
+// enabling DumpConfigFile / DumpConfigBytes for that extension. The common
+// pattern is one call per format, paired with an earlier RegisterConfigFormat:
+//
+//	boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
+//	boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
+//
+// If the extension hasn't been registered yet, a placeholder entry is created
+// with only Marshal set. Reading such a format then falls through to the JSON
+// fallback, which is almost never what you want — always register Unmarshal
+// too unless the format is genuinely dump-only.
+//
+// Registration is goroutine-safe. Passing nil panics.
+func RegisterConfigMarshaler(ext string, marshalFunc func(v any) ([]byte, error)) {
+	normalized := normalizeConfigExt(ext)
+	if marshalFunc == nil {
+		panic(fmt.Errorf("boa: RegisterConfigMarshaler(%q): marshalFunc must be non-nil", ext))
+	}
+	configFormatsMu.Lock()
+	defer configFormatsMu.Unlock()
+	cf := configFormats[normalized]
+	cf.Marshal = marshalFunc
+	configFormats[normalized] = cf
+}
+
 // normalizeConfigExt canonicalises an extension registration key into the
 // dot-prefixed form that filepath.Ext produces at lookup time. Accepts either
 // "yaml" or ".yaml" — both become ".yaml" — so users don't have to remember
@@ -797,6 +1163,34 @@ func resolveConfigFormatByExt(ext string, override ConfigFormat) ConfigFormat {
 		}
 	}
 	return ConfigFormat{Unmarshal: json.Unmarshal, KeyTree: jsonKeyTree}
+}
+
+// resolveConfigMarshalByExt picks the marshaler for the Dump* helpers.
+// Precedence: explicit override → registered format's Marshal → JSON pretty
+// fallback when no ext was supplied. Unlike the unmarshal path, a
+// *registered* format with a nil Marshal is an error, not a fallback —
+// emitting JSON bytes under a `.yaml` extension would silently corrupt the
+// file's type on disk.
+func resolveConfigMarshalByExt(ext string, override func(v any) ([]byte, error)) (func(v any) ([]byte, error), error) {
+	if override != nil {
+		return override, nil
+	}
+	if ext == "" {
+		return jsonMarshalPretty, nil
+	}
+	configFormatsMu.RLock()
+	cf, ok := configFormats[ext]
+	configFormatsMu.RUnlock()
+	if !ok {
+		// Unknown extension → same permissive default as the load path:
+		// fall through to JSON pretty. Callers that want a hard error for
+		// unknown extensions can check ConfigFormatExtensions() first.
+		return jsonMarshalPretty, nil
+	}
+	if cf.Marshal == nil {
+		return nil, fmt.Errorf("boa: no marshaler registered for config extension %q — call RegisterConfigMarshaler(%q, ...) or pass a marshalFunc", ext, ext)
+	}
+	return cf.Marshal, nil
 }
 
 // UnMarshalFromFileParam reads a file path from a parameter and unmarshals its contents into a target struct.

--- a/pkg/boa/config_file_test.go
+++ b/pkg/boa/config_file_test.go
@@ -2,9 +2,14 @@ package boa
 
 import (
 	"encoding/json"
+	"errors"
+	"net"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -464,5 +469,686 @@ func TestLoadConfigBytes(t *testing.T) {
 		if !ran {
 			t.Fatal("command did not run")
 		}
+	})
+}
+
+// --- Tests for DumpConfigBytes / DumpConfigFile ---
+
+func TestDumpConfigBytes(t *testing.T) {
+	type Params struct {
+		Host string `json:"Host"`
+		Port int    `json:"Port"`
+	}
+	sample := &Params{Host: "h", Port: 1234}
+
+	t.Run("default is pretty-printed JSON", func(t *testing.T) {
+		data, err := DumpConfigBytes(sample, "", nil)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		s := string(data)
+		if !strings.Contains(s, "\n") {
+			t.Errorf("expected multi-line pretty JSON, got %q", s)
+		}
+		if !strings.Contains(s, `"Host": "h"`) {
+			t.Errorf("expected indented pair in output, got %q", s)
+		}
+		if !strings.HasSuffix(s, "\n") {
+			t.Error("expected trailing newline in pretty JSON dump")
+		}
+	})
+
+	t.Run("round-trips through LoadConfigBytes", func(t *testing.T) {
+		data, err := DumpConfigBytes(sample, ".json", nil)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		var back Params
+		if err := LoadConfigBytes(data, ".json", &back, nil); err != nil {
+			t.Fatalf("LoadConfigBytes: %v", err)
+		}
+		if back != *sample {
+			t.Errorf("round-trip mismatch: got %+v want %+v", back, *sample)
+		}
+	})
+
+	t.Run("normalizes ext without leading dot", func(t *testing.T) {
+		data, err := DumpConfigBytes(sample, "json", nil)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		if !strings.Contains(string(data), `"Host"`) {
+			t.Errorf("expected JSON output, got %q", string(data))
+		}
+	})
+
+	t.Run("marshalFunc override wins", func(t *testing.T) {
+		called := false
+		custom := func(v any) ([]byte, error) {
+			called = true
+			return []byte("CUSTOM"), nil
+		}
+		data, err := DumpConfigBytes(sample, ".json", custom)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		if !called {
+			t.Error("expected custom marshalFunc to be called")
+		}
+		if string(data) != "CUSTOM" {
+			t.Errorf("expected CUSTOM, got %q", string(data))
+		}
+	})
+
+	t.Run("dispatches to registered format marshaler", func(t *testing.T) {
+		fakeMarshal := func(v any) ([]byte, error) {
+			out, err := json.Marshal(v)
+			if err != nil {
+				return nil, err
+			}
+			return append([]byte("FAKE:"), out...), nil
+		}
+		registerFormatCleanup(t, ".fakedump", ConfigFormat{
+			Unmarshal: fakeUnmarshal,
+			Marshal:   fakeMarshal,
+			KeyTree:   fakeKeyTree,
+		})
+
+		data, err := DumpConfigBytes(sample, ".fakedump", nil)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		if !strings.HasPrefix(string(data), "FAKE:") {
+			t.Errorf("expected FAKE-prefixed output, got %q", string(data))
+		}
+	})
+
+	t.Run("registered format without Marshal returns clear error", func(t *testing.T) {
+		registerFormatCleanup(t, ".nomarsh", ConfigFormat{
+			Unmarshal: fakeUnmarshal,
+			KeyTree:   fakeKeyTree,
+		})
+
+		_, err := DumpConfigBytes(sample, ".nomarsh", nil)
+		if err == nil {
+			t.Fatal("expected error when dumping format with no marshaler")
+		}
+		if !strings.Contains(err.Error(), "RegisterConfigMarshaler") {
+			t.Errorf("expected error to hint at RegisterConfigMarshaler, got: %v", err)
+		}
+	})
+
+	t.Run("unknown extension falls back to JSON pretty", func(t *testing.T) {
+		data, err := DumpConfigBytes(sample, ".nope", nil)
+		if err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		if !strings.Contains(string(data), `"Host": "h"`) {
+			t.Errorf("expected pretty JSON fallback, got %q", string(data))
+		}
+	})
+
+	t.Run("marshalFunc error is surfaced", func(t *testing.T) {
+		boom := errors.New("boom")
+		_, err := DumpConfigBytes(sample, "", func(v any) ([]byte, error) {
+			return nil, boom
+		})
+		if !errors.Is(err, boom) {
+			t.Errorf("expected wrapped boom error, got: %v", err)
+		}
+	})
+}
+
+func TestDumpConfigFile(t *testing.T) {
+	type Params struct {
+		Host string
+		Port int
+	}
+	sample := &Params{Host: "h", Port: 9090}
+
+	t.Run("writes pretty JSON to disk and round-trips", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.json")
+		if err := DumpConfigFile(path, sample, nil); err != nil {
+			t.Fatalf("DumpConfigFile: %v", err)
+		}
+		var back Params
+		if err := LoadConfigFile(path, &back, nil); err != nil {
+			t.Fatalf("LoadConfigFile: %v", err)
+		}
+		if back != *sample {
+			t.Errorf("round-trip mismatch: got %+v want %+v", back, *sample)
+		}
+	})
+
+	t.Run("overwrites existing file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.json")
+		if err := os.WriteFile(path, []byte("stale"), 0644); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		if err := DumpConfigFile(path, sample, nil); err != nil {
+			t.Fatalf("DumpConfigFile: %v", err)
+		}
+		data, _ := os.ReadFile(path)
+		if !strings.Contains(string(data), `"Host"`) {
+			t.Errorf("expected fresh JSON, got %q", string(data))
+		}
+	})
+
+	t.Run("empty filePath returns user input error", func(t *testing.T) {
+		err := DumpConfigFile("", sample, nil)
+		if err == nil {
+			t.Fatal("expected error for empty filePath")
+		}
+	})
+
+	t.Run("bad directory is surfaced as a write error", func(t *testing.T) {
+		err := DumpConfigFile("/nonexistent/dir/out.json", sample, nil)
+		if err == nil {
+			t.Fatal("expected error for unwritable path")
+		}
+	})
+
+	t.Run("marshalFunc override is honored", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "out.json")
+		custom := func(v any) ([]byte, error) { return []byte("HELLO"), nil }
+		if err := DumpConfigFile(path, sample, custom); err != nil {
+			t.Fatalf("DumpConfigFile: %v", err)
+		}
+		data, _ := os.ReadFile(path)
+		if string(data) != "HELLO" {
+			t.Errorf("expected HELLO, got %q", string(data))
+		}
+	})
+}
+
+func TestHookContext_DumpBytes_SourceAware(t *testing.T) {
+	type DB struct {
+		Host string `optional:"true"`
+		Port int    `optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Name       string `optional:"true"`
+		Age        int    `optional:"true" default:"42"`
+		Unset      string `optional:"true"`
+		Silent     bool   `optional:"true"`
+		DB         DB
+	}
+
+	parseDump := func(t *testing.T, data []byte) map[string]any {
+		t.Helper()
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal dump: %v\nraw: %s", err, string(data))
+		}
+		return m
+	}
+
+	t.Run("omits unset fields, keeps defaults and CLI values", func(t *testing.T) {
+		var captured []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, err := ctx.DumpBytes("", nil)
+				if err != nil {
+					t.Fatalf("DumpBytes: %v", err)
+				}
+				captured = data
+			},
+		}.RunArgs([]string{"--name", "alice", "--db-host", "h1"})
+
+		m := parseDump(t, captured)
+		if m["Name"] != "alice" {
+			t.Errorf("expected Name=alice, got %v", m["Name"])
+		}
+		// Age has a default → should appear even without CLI set
+		if v, ok := m["Age"]; !ok {
+			t.Error("expected Age in dump (default should be pinned)")
+		} else if int(v.(float64)) != 42 {
+			t.Errorf("expected Age=42, got %v", v)
+		}
+		if _, ok := m["Unset"]; ok {
+			t.Error("expected Unset to be omitted")
+		}
+		if _, ok := m["Silent"]; ok {
+			t.Error("expected Silent to be omitted (never set, no default)")
+		}
+		db, ok := m["DB"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected DB in dump, got %v", m["DB"])
+		}
+		if db["Host"] != "h1" {
+			t.Errorf("expected DB.Host=h1, got %v", db["Host"])
+		}
+		if _, ok := db["Port"]; ok {
+			t.Error("expected DB.Port to be omitted (never set)")
+		}
+	})
+
+	t.Run("skips the configfile field itself", func(t *testing.T) {
+		cfgPath := writeTestConfigFile(t, `{"Name":"bob"}`)
+
+		var captured []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, err := ctx.DumpBytes("", nil)
+				if err != nil {
+					t.Fatalf("DumpBytes: %v", err)
+				}
+				captured = data
+			},
+		}.RunArgs([]string{"--config-file", cfgPath})
+
+		m := parseDump(t, captured)
+		if _, ok := m["ConfigFile"]; ok {
+			t.Error("expected configfile path to be omitted from dump")
+		}
+		if m["Name"] != "bob" {
+			t.Errorf("expected Name=bob (from config file), got %v", m["Name"])
+		}
+	})
+
+	t.Run("prunes nested struct when no descendant is set", func(t *testing.T) {
+		var captured []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, err := ctx.DumpBytes("", nil)
+				if err != nil {
+					t.Fatalf("DumpBytes: %v", err)
+				}
+				captured = data
+			},
+		}.RunArgs([]string{"--name", "solo"})
+
+		m := parseDump(t, captured)
+		if _, ok := m["DB"]; ok {
+			t.Error("expected DB to be omitted when no descendant is set")
+		}
+	})
+
+	t.Run("dump round-trips through LoadConfigBytes", func(t *testing.T) {
+		// First run: set --name and --db-host, capture the dump.
+		var dumped []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, err := ctx.DumpBytes("", nil)
+				if err != nil {
+					t.Fatalf("DumpBytes: %v", err)
+				}
+				dumped = data
+			},
+		}.RunArgs([]string{"--name", "alice", "--db-host", "h1"})
+
+		// Second run: no CLI args, load from dumped bytes in PreValidate.
+		// Values should be recovered exactly, including pinned Age default.
+		var seen Params
+		CmdT[Params]{
+			Use: "test",
+			PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+				return LoadConfigBytes(dumped, "", p, nil)
+			},
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				seen = *p
+			},
+		}.RunArgs([]string{})
+
+		if seen.Name != "alice" {
+			t.Errorf("round-trip Name: got %q want alice", seen.Name)
+		}
+		if seen.Age != 42 {
+			t.Errorf("round-trip Age: got %d want 42", seen.Age)
+		}
+		if seen.DB.Host != "h1" {
+			t.Errorf("round-trip DB.Host: got %q want h1", seen.DB.Host)
+		}
+		if seen.DB.Port != 0 {
+			t.Errorf("round-trip DB.Port: got %d want 0 (not dumped)", seen.DB.Port)
+		}
+	})
+
+	t.Run("DumpFile writes source-aware output and round-trips", func(t *testing.T) {
+		dir := t.TempDir()
+		outPath := filepath.Join(dir, "out.json")
+
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				if err := ctx.DumpFile(outPath, nil); err != nil {
+					t.Fatalf("DumpFile: %v", err)
+				}
+			},
+		}.RunArgs([]string{"--name", "carol"})
+
+		data, err := os.ReadFile(outPath)
+		if err != nil {
+			t.Fatalf("read dump: %v", err)
+		}
+		m := parseDump(t, data)
+		if m["Name"] != "carol" {
+			t.Errorf("expected Name=carol in dump file, got %v", m["Name"])
+		}
+		if _, ok := m["Unset"]; ok {
+			t.Error("expected Unset to be omitted")
+		}
+	})
+}
+
+func TestHookContext_DumpBytes_AdvancedTypes(t *testing.T) {
+	// Embedded fields inside the top-level params exercise the "no named
+	// prefix" path: children appear flat in the output rather than nested
+	// under a wrapper key.
+	type Embedded struct {
+		EmbeddedField string `optional:"true"`
+	}
+	type Nested struct {
+		Inner string `optional:"true"`
+		Deep  struct {
+			Value int `optional:"true"`
+		}
+	}
+	type Params struct {
+		Embedded
+		StartAt time.Time     `optional:"true"`
+		Timeout time.Duration `optional:"true"`
+		Listen  net.IP        `optional:"true"`
+		Tags    []string      `optional:"true"`
+		Scores  []int         `optional:"true"`
+		Labels  map[string]string
+		Nested  Nested
+	}
+
+	// Run once with a rich set of values supplied via CLI.
+	var dumped []byte
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			data, err := ctx.DumpBytes("", nil)
+			if err != nil {
+				t.Fatalf("DumpBytes: %v", err)
+			}
+			dumped = data
+		},
+	}.RunArgs([]string{
+		"--embedded-field", "emb",
+		"--start-at", "2024-05-06T07:08:09Z",
+		"--timeout", "1h30m",
+		"--listen", "10.0.0.5",
+		"--tags", "a,b,c",
+		"--scores", "1,2,3",
+		"--labels", "env=prod,tier=api",
+		"--nested-inner", "n1",
+		"--nested-deep-value", "99",
+	})
+
+	t.Logf("dumped:\n%s", string(dumped))
+
+	// Parse into a plain map first so we can assert structure.
+	var tree map[string]any
+	if err := json.Unmarshal(dumped, &tree); err != nil {
+		t.Fatalf("parse dump: %v", err)
+	}
+
+	// Embedded field should be flat at the top level, not under "Embedded".
+	if tree["EmbeddedField"] != "emb" {
+		t.Errorf("expected EmbeddedField=emb at top level, got %v (full=%v)", tree["EmbeddedField"], tree)
+	}
+	if _, stillWrapped := tree["Embedded"]; stillWrapped {
+		t.Error("expected embedded fields to be flat, not under 'Embedded' key")
+	}
+
+	// time.Time serializes as RFC3339 string and round-trips through JSON.
+	// net.IP implements TextMarshaler, so it round-trips as a plain string.
+	// time.Duration serializes as int64 nanoseconds — works bidirectionally
+	// when the load path runs through boa's custom handler, but stdlib
+	// encoding/json will see it as a number (which json.Unmarshal cannot
+	// convert back to time.Duration directly). We verify the full
+	// round-trip via LoadConfigFile below, which runs boa's own
+	// post-unmarshal sync and therefore handles the special types
+	// correctly.
+
+	// Nested struct with deeper sub-struct.
+	nested, ok := tree["Nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Nested object, got %v", tree["Nested"])
+	}
+	if nested["Inner"] != "n1" {
+		t.Errorf("expected Nested.Inner=n1, got %v", nested["Inner"])
+	}
+	deep, ok := nested["Deep"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected Nested.Deep object, got %v", nested["Deep"])
+	}
+	if int(deep["Value"].(float64)) != 99 {
+		t.Errorf("expected Nested.Deep.Value=99, got %v", deep["Value"])
+	}
+
+	// Slices
+	tags, ok := tree["Tags"].([]any)
+	if !ok || len(tags) != 3 {
+		t.Errorf("expected Tags=[a b c], got %v", tree["Tags"])
+	}
+	scores, ok := tree["Scores"].([]any)
+	if !ok || len(scores) != 3 {
+		t.Errorf("expected Scores=[1 2 3], got %v", tree["Scores"])
+	}
+
+	// Map
+	labels, ok := tree["Labels"].(map[string]any)
+	if !ok || labels["env"] != "prod" || labels["tier"] != "api" {
+		t.Errorf("expected Labels={env:prod tier:api}, got %v", tree["Labels"])
+	}
+
+	// Full boa round-trip via a file load: run a second command that loads
+	// the dumped bytes via a configfile field, which exercises boa's own
+	// sync path for special types (time.Time, time.Duration, net.IP).
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "dump.json")
+	if err := os.WriteFile(cfgPath, dumped, 0644); err != nil {
+		t.Fatalf("write dump: %v", err)
+	}
+
+	type LoadParams struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		// Re-declare exactly as above so boa treats the dumped bytes as its
+		// own config. (We can't reuse Params because of the embedded field's
+		// cross-test-function visibility constraints.)
+		EmbeddedField string            `optional:"true"`
+		StartAt       time.Time         `optional:"true"`
+		Timeout       time.Duration     `optional:"true"`
+		Listen        net.IP            `optional:"true"`
+		Tags          []string          `optional:"true"`
+		Scores        []int             `optional:"true"`
+		Labels        map[string]string `optional:"true"`
+	}
+
+	var got LoadParams
+	CmdT[LoadParams]{
+		Use: "test2",
+		RunFunc: func(p *LoadParams, cmd *cobra.Command, args []string) {
+			got = *p
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+
+	if got.EmbeddedField != "emb" {
+		t.Errorf("round-trip EmbeddedField: got %q want emb", got.EmbeddedField)
+	}
+	wantTime, _ := time.Parse(time.RFC3339, "2024-05-06T07:08:09Z")
+	if !got.StartAt.Equal(wantTime) {
+		t.Errorf("round-trip StartAt: got %v want %v", got.StartAt, wantTime)
+	}
+	if got.Timeout != 90*time.Minute {
+		t.Errorf("round-trip Timeout: got %v want 1h30m", got.Timeout)
+	}
+	if !got.Listen.Equal(net.ParseIP("10.0.0.5")) {
+		t.Errorf("round-trip Listen: got %v want 10.0.0.5", got.Listen)
+	}
+	if !reflect.DeepEqual(got.Tags, []string{"a", "b", "c"}) {
+		t.Errorf("round-trip Tags: got %v want [a b c]", got.Tags)
+	}
+	if !reflect.DeepEqual(got.Scores, []int{1, 2, 3}) {
+		t.Errorf("round-trip Scores: got %v want [1 2 3]", got.Scores)
+	}
+	if got.Labels["env"] != "prod" || got.Labels["tier"] != "api" {
+		t.Errorf("round-trip Labels: got %v want env=prod tier=api", got.Labels)
+	}
+}
+
+func TestHookContext_DumpBytes_HonorsJSONTags(t *testing.T) {
+	type Params struct {
+		Host    string `json:"hostname" optional:"true"`
+		Port    int    `json:"port,omitempty" optional:"true"`
+		Private string `json:"-" optional:"true"`
+		Plain   string `optional:"true"`
+	}
+
+	var dumped []byte
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			data, err := ctx.DumpBytes("", nil)
+			if err != nil {
+				t.Fatalf("DumpBytes: %v", err)
+			}
+			dumped = data
+		},
+	// CLI flag names come from the Go field name, not the json tag — the
+	// json tag only affects how the dump/load cycle serializes and parses
+	// the value.
+	}.RunArgs([]string{
+		"--host", "h",
+		"--port", "9000",
+		"--private", "secret",
+		"--plain", "p",
+	})
+
+	var m map[string]any
+	if err := json.Unmarshal(dumped, &m); err != nil {
+		t.Fatalf("parse: %v\nraw: %s", err, string(dumped))
+	}
+
+	// Tag value renames Host → hostname.
+	if m["hostname"] != "h" {
+		t.Errorf("expected hostname=h, got %v", m["hostname"])
+	}
+	if _, ok := m["Host"]; ok {
+		t.Error("expected Host (Go field name) to be absent — json tag rename")
+	}
+	// omitempty suffix is ignored; we still emit the field because it's set.
+	if int(m["port"].(float64)) != 9000 {
+		t.Errorf("expected port=9000, got %v", m["port"])
+	}
+	// "-" tag means "skip entirely".
+	if _, ok := m["Private"]; ok {
+		t.Error("expected Private to be absent (json:\"-\")")
+	}
+	if _, ok := m["private"]; ok {
+		t.Error("expected private to be absent (json:\"-\")")
+	}
+	// Untagged field falls back to Go field name.
+	if m["Plain"] != "p" {
+		t.Errorf("expected Plain=p (field-name fallback), got %v", m["Plain"])
+	}
+
+	// Full round-trip: the dumped bytes should re-load cleanly into the
+	// same struct because json.Unmarshal honours json:"hostname" on the
+	// target field too.
+	var back Params
+	if err := LoadConfigBytes(dumped, "", &back, nil); err != nil {
+		t.Fatalf("LoadConfigBytes: %v", err)
+	}
+	if back.Host != "h" {
+		t.Errorf("round-trip Host: got %q want h", back.Host)
+	}
+	if back.Port != 9000 {
+		t.Errorf("round-trip Port: got %d want 9000", back.Port)
+	}
+	if back.Plain != "p" {
+		t.Errorf("round-trip Plain: got %q want p", back.Plain)
+	}
+	if back.Private != "" {
+		t.Errorf("round-trip Private: got %q want empty (json:\"-\" means no data)", back.Private)
+	}
+}
+
+func TestHookContext_DumpBytes_OptionalPointerStruct(t *testing.T) {
+	// Exercise the "pointer struct acts as optional parameter group" path:
+	// when the user doesn't touch DB at all, DB should be completely absent
+	// from the dump (not an empty {} and not a null field).
+	type DB struct {
+		Host string `optional:"true"`
+		Port int    `optional:"true"`
+	}
+	type Params struct {
+		Name string `optional:"true"`
+		DB   *DB
+	}
+
+	t.Run("set → emitted, unset → omitted", func(t *testing.T) {
+		var dumpWithDB []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, _ := ctx.DumpBytes("", nil)
+				dumpWithDB = data
+			},
+		}.RunArgs([]string{"--name", "n", "--db-host", "h"})
+
+		var m1 map[string]any
+		_ = json.Unmarshal(dumpWithDB, &m1)
+		if _, ok := m1["DB"]; !ok {
+			t.Error("expected DB in dump when at least one subfield set")
+		}
+
+		var dumpNoDB []byte
+		CmdT[Params]{
+			Use: "test",
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				data, _ := ctx.DumpBytes("", nil)
+				dumpNoDB = data
+			},
+		}.RunArgs([]string{"--name", "n"})
+
+		var m2 map[string]any
+		_ = json.Unmarshal(dumpNoDB, &m2)
+		if _, ok := m2["DB"]; ok {
+			t.Error("expected DB to be absent from dump when no subfield set")
+		}
+	})
+}
+
+func TestRegisterConfigMarshaler(t *testing.T) {
+	t.Run("attaches marshaler to existing format", func(t *testing.T) {
+		registerFormatCleanup(t, ".rw1", UniversalConfigFormat(fakeUnmarshal))
+
+		marshalCalled := false
+		RegisterConfigMarshaler(".rw1", func(v any) ([]byte, error) {
+			marshalCalled = true
+			return json.Marshal(v)
+		})
+		// Undo the marshaler via cleanup: registerFormatCleanup re-registers
+		// the original entry, which has no Marshal, on test end.
+
+		type P struct{ X int }
+		if _, err := DumpConfigBytes(&P{X: 1}, ".rw1", nil); err != nil {
+			t.Fatalf("DumpConfigBytes: %v", err)
+		}
+		if !marshalCalled {
+			t.Error("expected marshaler to be called")
+		}
+	})
+
+	t.Run("panics on nil", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected panic on nil marshalFunc")
+			}
+		}()
+		RegisterConfigMarshaler(".rw2", nil)
 	})
 }


### PR DESCRIPTION
## Summary

Adds serialization to pair with `LoadConfigFile` / `LoadConfigBytes`:

- **`boa.DumpConfigBytes`** / **`boa.DumpConfigFile`** — naive dump of the whole struct, including Go zero values. Useful for "generate an example config that shows every option" and round-trip tests.
- **`ctx.DumpBytes`** / **`ctx.DumpFile`** on `HookContext` — **source-aware** dump that emits only fields where `HasValue` reports true (CLI, env, config file, default). Fields the user never touched are omitted entirely. This is the right helper for persisting resolved config between runs.

Source-aware dump deliberately pins defaults into the file: a future release that ships different built-in defaults can't silently change behavior for users whose saved config said "I'm happy with what shipped in v1.0". The `configfile` path parameter itself is omitted so the dumped file doesn't reference its own path on the next load.

## Registry changes

- `ConfigFormat` grows an optional `Marshal func(v any) ([]byte, error)` field.
- Built-in JSON ships with a pretty-printed marshaler (2-space indent, trailing newline).
- New `boa.RegisterConfigMarshaler(ext, marshalFunc)` attaches a marshaler to a registered (or new) format. Pair with `RegisterConfigFormat` to enable dump support for YAML/TOML/etc:
  ```go
  boa.RegisterConfigFormat(".yaml", yaml.Unmarshal)
  boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
  ```
- Trying to dump a registered format that has no marshaler returns a clear error — no silent cross-format fallback (writing JSON bytes to a `.yaml` file would be a nasty surprise).

## Source-aware walker details

- Honours format-appropriate struct tags for key names: `json:"name"` for `.json`, `yaml:"name"` for `.yaml`/`.yml`, `toml:"name"` for `.toml`, `hcl:"name"` for `.hcl`. Untagged fields fall back to Go field names. `json:"-"` skips the field entirely. `name,omitempty` suffix is parsed correctly.
- Anonymous embedded structs flatten their children into the parent map (matches boa's flag-generation semantics and `encoding/json`'s default behavior).
- Nested structs with no set descendants are omitted entirely (not emitted as empty objects). Same for nil optional pointer-struct groups (`DB *DBConfig`).
- Bool fields whose only source is the auto-installed `false` default from `ParamEnricherBool` are treated as unset, so dumps don't fill up with `"Silent": false` for every flag the user never flipped. Users who want an explicit emission can run with `--flag=false` once; the source tracking records `wasSetOnCli` and the dump emits it.

## Tests

- Tag renaming (`json:\"hostname\"` → output key `hostname`)
- Tag skip (`json:\"-\"`)
- `omitempty` suffix parsing (name is extracted, option discarded)
- Source-aware: unset fields omitted, defaults kept, CLI values kept
- Nested struct pruning when no descendant is set
- `configfile` path always omitted
- Optional pointer-struct groups: emit when any child set, omit otherwise
- Advanced types: `time.Time`, `time.Duration`, `net.IP`, slices, maps, nested structs, embedded fields
- Full round-trip: dump bytes → write file → load via `configfile` → struct equality check
- Registry: `RegisterConfigMarshaler` attaches to existing entry, panics on nil
- Naive `DumpConfigBytes`: default pretty JSON, ext normalization, `marshalFunc` override, registered-format dispatch, missing-marshaler error, unknown-ext fallback, error surfacing
- `DumpConfigFile`: round-trips through load, overwrites existing files, empty-path error, write error surfacing

## Test plan
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration can now be serialized and written back to disk in multiple formats.
  * Two dump modes available: basic (all fields) and source-aware (only modified fields).
  * Custom marshaling support for various configuration formats.

* **Documentation**
  * Added comprehensive guides and examples for writing configuration output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->