### PR TITLE
feat: multi-file configfile overlay chains

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -290,9 +290,36 @@ Substruct configs load first, then root config loads and overrides any overlappi
 
 This lets you split configuration across multiple files while maintaining a clear override hierarchy.
 
-### Using `LoadConfigFile` Explicitly
+### Multi-File Overlay Chains
 
-For more control (e.g., loading into a sub-struct, multiple config files), use `LoadConfigFile` in a PreValidate hook:
+A `configfile:"true"` field can also be a `[]string`, which turns the field into a left-to-right overlay chain: later files overlay earlier ones at the key level. This is the classic `config.json` + `config.local.json` (or `base.yaml` + `production.yaml`) pattern:
+
+```go
+type Params struct {
+    ConfigFiles []string `configfile:"true" optional:"true"`
+    Host        string   `optional:"true"`
+    Port        int      `optional:"true"`
+}
+
+// CLI:  app --config-files base.json,local.json
+// Or:   app --config-files base.json --config-files local.json
+```
+
+The overlay semantics are just repeated `json.Unmarshal` into the same struct:
+
+- Keys mentioned in the later file replace what earlier files loaded
+- Keys absent from the later file leave earlier values alone
+- Slices and maps are *fully replaced* by the later file (not merged) — if base has `Tags: [a, b]` and local has `Tags: [c]`, the final value is `[c]`
+- Empty strings in the list are skipped silently
+- Missing files produce a clean error naming which file failed
+
+Substruct `[]string` configfile fields get their own independent chains, and the usual root-vs-substruct priority still applies: every substruct chain loads first, then the root chain loads last.
+
+See [examples-config.md](examples-config.md#multi-file-overlay-base--local-cascade) for full examples.
+
+### Using `LoadConfigFile` / `LoadConfigFiles` Explicitly
+
+For more control (e.g., loading into a sub-struct, building the path list dynamically), use `LoadConfigFile` or `LoadConfigFiles` in a PreValidate hook:
 
 ```go
 type AppConfig struct {
@@ -308,7 +335,16 @@ type Params struct {
 boa.CmdT[Params]{
     Use: "app",
     PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
-        return boa.LoadConfigFile(p.ConfigFile, &p.AppConfig, nil)
+        // Single file:
+        // return boa.LoadConfigFile(p.ConfigFile, &p.AppConfig, nil)
+
+        // Or an overlay chain built at runtime:
+        paths := []string{
+            "/etc/myapp/config.json",
+            filepath.Join(os.Getenv("HOME"), ".myapp.json"),
+            "./myapp.local.json",
+        }
+        return boa.LoadConfigFiles(paths, &p.AppConfig, nil)
     },
     RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
         fmt.Printf("Host: %s, Port: %d\n", p.Host, p.Port)

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -655,6 +655,72 @@ func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte
 - `target`: pointer to the struct to populate
 - `unmarshalFunc`: custom unmarshal function (`nil` uses file extension detection, then falls back to `json.Unmarshal`)
 
+## Multi-File Overlay (Base + Local Cascade)
+
+For the classic 12-factor `config.json` + `config.local.json` pattern, declare the configfile field as a `[]string` — later files overlay earlier ones at the key level:
+
+```go
+type Params struct {
+    ConfigFiles []string `configfile:"true" optional:"true"`
+    Host        string   `optional:"true"`
+    Port        int      `optional:"true"`
+}
+
+// CLI:
+//   app --config-files base.json,local.json
+//   app --config-files base.json --config-files prod.json
+```
+
+`base.json`:
+```json
+{"Host": "app.example.com", "Port": 80}
+```
+
+`local.json` (developer override):
+```json
+{"Port": 8080}
+```
+
+After the chain loads, the resolved parameters are `Host=app.example.com` (from base, unchanged by local) and `Port=8080` (local overlaid base). Keys that are absent in the later file leave the earlier values intact — that's the natural behavior of sequential `json.Unmarshal` calls into the same struct.
+
+### Overlay semantics
+
+- **Order**: left-to-right is lowest-to-highest precedence. The rightmost file wins for any key it mentions.
+- **Missing keys**: leave earlier values alone. Not-mentioned ≠ reset.
+- **Slices and maps**: *fully replaced* by the later file, not merged. If base has `Tags: [a, b]` and local has `Tags: [c]`, the final value is `[c]`. This is standard `json.Unmarshal` behavior and matches what almost every config-cascade user expects. (Deep merging is deliberately out of scope.)
+- **CLI and env still win**: the full precedence chain is unchanged — CLI > env > root config chain > substruct config chain > defaults. The multi-file chain slots in at "root config" (or "substruct config" for nested declarations).
+- **Substructs** can declare their own `[]string` configfile chain too, and each chain loads independently. Substruct chains load first, the root chain loads last.
+- **Empty strings** in the list are skipped silently — handy when an optional overlay is computed at runtime.
+- **Missing files** produce a clean error naming the file that failed.
+
+### `LoadConfigFiles` helper
+
+If you'd rather build the path list yourself (e.g. from environment, computed from the user's home directory, or mixing embedded defaults with on-disk overrides), use the helper in a `PreValidateFunc`:
+
+```go
+func main() {
+    boa.CmdT[Params]{
+        Use: "app",
+        PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+            paths := []string{
+                "/etc/myapp/config.json",                  // system defaults
+                filepath.Join(os.Getenv("HOME"), ".myapp.json"), // user overrides
+                "./myapp.local.json",                      // per-project overrides
+            }
+            return boa.LoadConfigFiles(paths, p, nil)
+        },
+    }.Run()
+}
+```
+
+Signature:
+
+```go
+func LoadConfigFiles[T any](paths []string, target *T, unmarshalFunc func([]byte, any) error) error
+```
+
+Empty strings in `paths` are skipped; a nil or empty slice is a no-op. Loading stops at the first missing file and returns the underlying error.
+
 ## Loading Config From Bytes
 
 When the config does not live on disk — for example, `//go:embed` assets, stdin, an HTTP response body, or a test fixture — use `boa.LoadConfigBytes`. It shares the same format-resolution rules as `LoadConfigFile`, so registered formats like YAML or TOML work exactly the same.

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -779,6 +779,41 @@ func LoadConfigFile[T any](filePath string, target *T, unmarshalFunc func([]byte
 	return err
 }
 
+// LoadConfigFiles reads a left-to-right overlay chain of config files and
+// unmarshals each one into the target struct. Later files overlay earlier
+// ones at the key level — keys present in file N replace the values loaded
+// from files 0..N-1, while keys only present in earlier files are left
+// alone. This is the classic 12-factor `config.json` + `config.local.json`
+// pattern, or `base.yaml` + `production.yaml`:
+//
+//	boa.LoadConfigFiles([]string{"config.json", "config.local.json"}, p, nil)
+//
+// Empty-string entries are skipped silently, so callers can hand in a list
+// that includes an optional override without a preceding filter. A nil or
+// empty paths slice is a no-op.
+//
+// Slices and maps are fully replaced by the later file — json.Unmarshal
+// overwrites the whole field when a key appears, it does not merge. If the
+// base file has `Tags: [a, b]` and the overlay has `Tags: [c]`, the final
+// value is `[c]`. (Deep merging is deliberately out of scope here; the
+// cascading replace semantics are what most users expect for configfile
+// overlays and map/slice merging is hard to make unsurprising.)
+//
+// Format resolution is per-file, so a chain may mix formats (e.g. a
+// registered .yaml base with a .json overlay) as long as both formats
+// have registered unmarshalers.
+func LoadConfigFiles[T any](paths []string, target *T, unmarshalFunc func([]byte, any) error) error {
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		if err := LoadConfigFile(p, target, unmarshalFunc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // LoadConfigBytes unmarshals raw config bytes into the target struct, using
 // the same format-resolution rules as LoadConfigFile. This is the in-memory
 // counterpart for cases where the bytes do not come from a local file —

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -237,9 +237,31 @@ type Param interface {
 
 // configFileEntry tracks a configfile:"true" field and the struct it should load into.
 type configFileEntry struct {
-	mirror     Param     // the string param holding the file path
+	mirror     Param     // the string / []string param holding the file path(s)
 	target     any       // pointer to the struct to unmarshal into
 	targetPath fieldPath // path from root to the target struct (empty for root)
+}
+
+// configFilePathsFromMirror reads the current value of a configfile mirror and
+// returns the ordered list of file paths to load. A string-typed mirror yields
+// at most one path; a []string-typed mirror yields the slice verbatim (empty
+// entries are the caller's responsibility to skip). Any other type indicates
+// a bug — the traversal-time guard should have rejected it already.
+func configFilePathsFromMirror(mirror Param) []string {
+	ptr := mirror.valuePtrF()
+	switch v := ptr.(type) {
+	case *string:
+		if v == nil || *v == "" {
+			return nil
+		}
+		return []string{*v}
+	case *[]string:
+		if v == nil {
+			return nil
+		}
+		return *v
+	}
+	return nil
 }
 
 // fieldPath is the dot-separated sequence of struct-field declaration indices
@@ -1971,8 +1993,14 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				param.SetConfigFile(true)
 			}
 			if param.IsConfigFile() {
-				if param.GetType().Kind() != reflect.String {
-					return fmt.Errorf("configfile on param %s: must be a string field", param.GetName())
+				// Accept either `string` (single config file) or `[]string`
+				// (overlay chain: later paths override earlier at the key
+				// level). Any other type is a programmer error.
+				pt := param.GetType()
+				isString := pt.Kind() == reflect.String
+				isStringSlice := pt.Kind() == reflect.Slice && pt.Elem().Kind() == reflect.String
+				if !isString && !isStringSlice {
+					return fmt.Errorf("configfile on param %s: must be a string or []string field", param.GetName())
 				}
 				// The target struct path is the parent of the configfile param's own path.
 				// Read it directly from paramMeta.pathKey (stashed during traverse) —
@@ -2189,30 +2217,45 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 						subEntries = append(subEntries, entry)
 					}
 				}
+				loadEntry := func(entry configFileEntry) error {
+					if !entry.mirror.HasValue() {
+						return nil
+					}
+					// String fields load one file; []string fields load a
+					// left-to-right overlay chain where each file's keys
+					// cascade into the target struct. Later files overlay
+					// earlier at the key level — missing keys leave the
+					// previous value alone because json.Unmarshal only
+					// writes fields that appear in the input.
+					paths := configFilePathsFromMirror(entry.mirror)
+					for _, filePath := range paths {
+						if filePath == "" {
+							continue
+						}
+						rawData, effective, err := loadConfigFileInto(filePath, entry.target, cmdOverride)
+						if err != nil {
+							return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
+						}
+						configResults = append(configResults, configLoadResult{
+							target:     entry.target,
+							targetPath: entry.targetPath,
+							rawData:    rawData,
+							format:     effective,
+							ext:        filepath.Ext(filePath),
+						})
+					}
+					return nil
+				}
 				// Load substruct configs first
 				for _, entry := range subEntries {
-					if entry.mirror.HasValue() {
-						filePath := *(entry.mirror.valuePtrF().(*string))
-						if filePath != "" {
-							rawData, effective, err := loadConfigFileInto(filePath, entry.target, cmdOverride)
-							if err != nil {
-								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
-							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective, ext: filepath.Ext(filePath)})
-						}
+					if err := loadEntry(entry); err != nil {
+						return err
 					}
 				}
 				// Then load root config (overrides substruct values)
 				for _, entry := range rootEntries {
-					if entry.mirror.HasValue() {
-						filePath := *(entry.mirror.valuePtrF().(*string))
-						if filePath != "" {
-							rawData, effective, err := loadConfigFileInto(filePath, entry.target, cmdOverride)
-							if err != nil {
-								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
-							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective, ext: filepath.Ext(filePath)})
-						}
+					if err := loadEntry(entry); err != nil {
+						return err
 					}
 				}
 				syncMirrors(ctx)

--- a/pkg/boa/multi_configfile_test.go
+++ b/pkg/boa/multi_configfile_test.go
@@ -1,0 +1,351 @@
+package boa
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// writeFile is a tiny helper for the overlay tests — keeps each test body
+// focused on the overlay semantics rather than temp-file plumbing.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// --- []string configfile tag: tag-driven overlay chain ---
+
+func TestMultiConfigFile_StringSliceTag(t *testing.T) {
+	type Params struct {
+		ConfigFiles []string `configfile:"true" optional:"true"`
+		Host        string   `optional:"true"`
+		Port        int      `optional:"true"`
+		Region      string   `optional:"true"`
+		Tags        []string `optional:"true"`
+	}
+
+	t.Run("later file overlays earlier at the key level", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base","Port":80,"Region":"us"}`)
+		local := writeFile(t, dir, "local.json", `{"Port":8080,"Region":"eu"}`)
+
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{"--config-files", base + "," + local})
+
+		if got.Host != "base" {
+			t.Errorf("Host: expected 'base' (from base, not overridden), got %q", got.Host)
+		}
+		if got.Port != 8080 {
+			t.Errorf("Port: expected 8080 (local overlays base), got %d", got.Port)
+		}
+		if got.Region != "eu" {
+			t.Errorf("Region: expected 'eu' (local overlays base), got %q", got.Region)
+		}
+	})
+
+	t.Run("slice field is fully replaced by the later file", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Tags":["a","b"]}`)
+		local := writeFile(t, dir, "local.json", `{"Tags":["c"]}`)
+
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{"--config-files", base + "," + local})
+
+		if len(got.Tags) != 1 || got.Tags[0] != "c" {
+			t.Errorf("Tags: expected [c] (full replace), got %v", got.Tags)
+		}
+	})
+
+	t.Run("single-element list behaves like a plain string configfile", func(t *testing.T) {
+		dir := t.TempDir()
+		only := writeFile(t, dir, "only.json", `{"Host":"solo","Port":1}`)
+
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{"--config-files", only})
+
+		if got.Host != "solo" || got.Port != 1 {
+			t.Errorf("single-element: got %+v", got)
+		}
+	})
+
+	t.Run("empty list is a no-op", func(t *testing.T) {
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{})
+
+		if got.Host != "" || got.Port != 0 {
+			t.Errorf("expected zero params with empty config-files, got %+v", got)
+		}
+	})
+
+	t.Run("missing file in chain returns a clear error", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base"}`)
+
+		err := CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				t.Fatal("should not run")
+			},
+			RawArgs: []string{"--config-files", base + ",/nonexistent/overlay.json"},
+		}.Validate()
+
+		if err == nil {
+			t.Fatal("expected error for missing file in chain")
+		}
+		if !strings.Contains(err.Error(), "/nonexistent/overlay.json") {
+			t.Errorf("expected error to name the bad file, got: %v", err)
+		}
+	})
+
+	t.Run("CLI overrides every file in the chain", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base","Port":80}`)
+		local := writeFile(t, dir, "local.json", `{"Port":8080}`)
+
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{
+			"--config-files", base + "," + local,
+			"--host", "from-cli",
+			"--port", "9999",
+		})
+
+		if got.Host != "from-cli" {
+			t.Errorf("expected Host=from-cli (CLI wins), got %q", got.Host)
+		}
+		if got.Port != 9999 {
+			t.Errorf("expected Port=9999 (CLI wins), got %d", got.Port)
+		}
+	})
+}
+
+// --- HasValue tracking across overlay chains ---
+
+func TestMultiConfigFile_HasValueAcrossChain(t *testing.T) {
+	type Params struct {
+		ConfigFiles []string `configfile:"true" optional:"true"`
+		Host        string   `optional:"true"`
+		Port        int      `optional:"true"`
+		OnlyInBase  string   `optional:"true"`
+	}
+
+	dir := t.TempDir()
+	base := writeFile(t, dir, "base.json", `{"Host":"base","OnlyInBase":"x"}`)
+	local := writeFile(t, dir, "local.json", `{"Port":8080}`)
+
+	var (
+		hostHasValue   bool
+		portHasValue   bool
+		onlyHasValue   bool
+	)
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			hostHasValue = ctx.HasValue(&p.Host)
+			portHasValue = ctx.HasValue(&p.Port)
+			onlyHasValue = ctx.HasValue(&p.OnlyInBase)
+		},
+	}.RunArgs([]string{"--config-files", base + "," + local})
+
+	if !hostHasValue {
+		t.Error("expected HasValue(Host)=true (set by base)")
+	}
+	if !portHasValue {
+		t.Error("expected HasValue(Port)=true (set by local)")
+	}
+	if !onlyHasValue {
+		t.Error("expected HasValue(OnlyInBase)=true (set by base, unchanged by local)")
+	}
+}
+
+// --- Programmatic SetConfigFile on []string ---
+
+func TestMultiConfigFile_ProgrammaticSetConfigFile(t *testing.T) {
+	type Params struct {
+		ConfigFiles []string `optional:"true"`
+		Host        string   `optional:"true"`
+		Port        int      `optional:"true"`
+	}
+
+	dir := t.TempDir()
+	base := writeFile(t, dir, "base.json", `{"Host":"base","Port":80}`)
+	local := writeFile(t, dir, "local.json", `{"Port":8080}`)
+
+	var got Params
+	CmdT[Params]{
+		Use: "test",
+		InitFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command) error {
+			ctx.GetParam(&p.ConfigFiles).SetConfigFile(true)
+			return nil
+		},
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			got = *p
+		},
+	}.RunArgs([]string{"--config-files", base + "," + local})
+
+	if got.Host != "base" {
+		t.Errorf("Host: expected 'base', got %q", got.Host)
+	}
+	if got.Port != 8080 {
+		t.Errorf("Port: expected 8080, got %d", got.Port)
+	}
+}
+
+// --- Substruct overlay chain interacting with root ---
+
+func TestMultiConfigFile_SubstructAndRoot(t *testing.T) {
+	type DB struct {
+		ConfigFiles []string `configfile:"true" optional:"true"`
+		Host        string   `optional:"true"`
+		Port        int      `optional:"true"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Name       string `optional:"true"`
+		DB         DB
+	}
+
+	dir := t.TempDir()
+	dbBase := writeFile(t, dir, "db-base.json", `{"Host":"db-base","Port":5432}`)
+	dbLocal := writeFile(t, dir, "db-local.json", `{"Host":"db-local"}`)
+	root := writeFile(t, dir, "root.json", `{"Name":"app","DB":{"Port":6000}}`)
+
+	var got Params
+	CmdT[Params]{
+		Use: "test",
+		RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+			got = *p
+		},
+	}.RunArgs([]string{
+		"--config-file", root,
+		"--db-config-files", dbBase + "," + dbLocal,
+	})
+
+	// Substruct chain loads first: dbBase then dbLocal → Host=db-local, Port=5432
+	// Root loads last, overriding DB.Port → 6000. DB.Host remains db-local
+	// because root.json doesn't mention it.
+	if got.Name != "app" {
+		t.Errorf("Name: expected 'app', got %q", got.Name)
+	}
+	if got.DB.Host != "db-local" {
+		t.Errorf("DB.Host: expected 'db-local' (substruct overlay result), got %q", got.DB.Host)
+	}
+	if got.DB.Port != 6000 {
+		t.Errorf("DB.Port: expected 6000 (root overrides substruct), got %d", got.DB.Port)
+	}
+}
+
+// --- Public LoadConfigFiles helper (for hook-based users) ---
+
+func TestLoadConfigFiles_PublicHelper(t *testing.T) {
+	type Params struct {
+		Host string `optional:"true"`
+		Port int    `optional:"true"`
+	}
+
+	t.Run("overlays in order", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base","Port":80}`)
+		local := writeFile(t, dir, "local.json", `{"Port":8080}`)
+
+		var p Params
+		if err := LoadConfigFiles([]string{base, local}, &p, nil); err != nil {
+			t.Fatalf("LoadConfigFiles: %v", err)
+		}
+		if p.Host != "base" {
+			t.Errorf("Host: expected 'base', got %q", p.Host)
+		}
+		if p.Port != 8080 {
+			t.Errorf("Port: expected 8080, got %d", p.Port)
+		}
+	})
+
+	t.Run("empty-string entries are skipped silently", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base"}`)
+
+		var p Params
+		if err := LoadConfigFiles([]string{"", base, ""}, &p, nil); err != nil {
+			t.Fatalf("LoadConfigFiles: %v", err)
+		}
+		if p.Host != "base" {
+			t.Errorf("expected Host=base, got %q", p.Host)
+		}
+	})
+
+	t.Run("nil and empty lists are no-ops", func(t *testing.T) {
+		var p Params
+		if err := LoadConfigFiles(nil, &p, nil); err != nil {
+			t.Fatalf("nil: %v", err)
+		}
+		if err := LoadConfigFiles([]string{}, &p, nil); err != nil {
+			t.Fatalf("empty: %v", err)
+		}
+	})
+
+	t.Run("stops at the first missing file", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base"}`)
+
+		var p Params
+		err := LoadConfigFiles([]string{base, "/nonexistent/overlay.json"}, &p, nil)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+		if p.Host != "base" {
+			t.Errorf("expected first file to have loaded before the error, got %q", p.Host)
+		}
+	})
+
+	t.Run("works inside PreValidateFunc", func(t *testing.T) {
+		dir := t.TempDir()
+		base := writeFile(t, dir, "base.json", `{"Host":"base","Port":80}`)
+		local := writeFile(t, dir, "local.json", `{"Port":8080}`)
+
+		var got Params
+		CmdT[Params]{
+			Use: "test",
+			PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+				return LoadConfigFiles([]string{base, local}, p, nil)
+			},
+			RunFunc: func(p *Params, cmd *cobra.Command, args []string) {
+				got = *p
+			},
+		}.RunArgs([]string{})
+
+		if got.Host != "base" || got.Port != 8080 {
+			t.Errorf("PreValidate overlay: got %+v", got)
+		}
+	})
+}

--- a/pkg/boa/substruct_configfile_test.go
+++ b/pkg/boa/substruct_configfile_test.go
@@ -495,8 +495,8 @@ func TestProgrammaticSetConfigFile_NonStringRejected(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for SetConfigFile on int field, got nil")
 	}
-	if !strings.Contains(err.Error(), "must be a string field") {
-		t.Errorf("expected 'must be a string field' error, got %v", err)
+	if !strings.Contains(err.Error(), "must be a string or []string field") {
+		t.Errorf("expected 'must be a string or []string field' error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

A `configfile:\"true\"` field can now be a `[]string` as well as a `string`. When it's a slice, boa loads the files left-to-right into the same target struct — the classic 12-factor \`config.json + config.local.json\` cascade where later files overlay earlier ones at the key level.

\`\`\`go
type Params struct {
    ConfigFiles []string \`configfile:\"true\" optional:\"true\"\`
    Host        string
    Port        int
}
// app --config-files base.json,local.json
\`\`\`

Also adds \`boa.LoadConfigFiles(paths, target, unmarshalFunc)\` as a public helper for users who'd rather build the path list themselves in \`PreValidateFunc\` (system defaults from \`/etc\`, overrides from \`\$HOME\`, per-project override in \`./\`, etc.).

## Overlay semantics

It's just repeated \`json.Unmarshal\` into the same target struct:

- Keys mentioned in a later file **replace** earlier values.
- Keys **absent** in the later file leave earlier values alone.
- Slices and maps are **fully replaced** by the later file (standard \`json.Unmarshal\` behavior). \`Tags: [a, b]\` in base + \`Tags: [c]\` in local → final \`[c]\`.
- Empty-string entries are skipped silently.
- Missing files produce a clear error naming which file failed.
- **CLI and env still win** over the whole chain. The multi-file chain slots in at the existing \"root config\" (or \"substruct config\" for nested declarations) precedence level.

**Deep merging is deliberately out of scope.** Slice append vs replace vs merge-by-key, map replace vs merge-keys, \"empty means unset\" heuristics — every policy is controversial and third-party libraries (mergo, koanf) already solve them better. Users who want a specific merge policy can pass a custom \`unmarshalFunc\` that wraps \`json.Unmarshal\` + \`mergo.Merge\` and get full control. That extension point already exists and composes cleanly with the \`[]string\` tag via \`Cmd.ConfigUnmarshal\`.

## Substructs

Substruct \`[]string\` configfile fields get their own independent chains. The existing root-vs-substruct priority still holds: every substruct chain loads first, the root chain loads last, so the full hierarchy is:

\`CLI > env > root chain (left-to-right) > substruct chains (left-to-right) > defaults > zero value\`

## Implementation

- Relaxed the type guard in \`internal.go\` to accept \`reflect.String\` OR \`reflect.Slice\` of string kind.
- Added \`configFilePathsFromMirror\` helper that reads the mirror value and returns \`[]string\` regardless of underlying type.
- Refactored the two load loops (substruct then root) into a shared \`loadEntry\` closure that iterates paths and appends one \`configLoadResult\` per file, so the existing key-presence probe loop handles each file independently and \`HasValue\` correctly reflects \"set by any file in the chain\".
- Added \`boa.LoadConfigFiles[T]\` as a thin loop over \`LoadConfigFile\` in \`api_base.go\`.
- Programmatic \`SetConfigFile(true)\` now works on \`[]string\` fields too — same relaxed type guard.

## Tests

New \`multi_configfile_test.go\` covers:

- Tag-driven \`[]string\` overlay (later file wins at key level, slice full replace)
- Single-element slice behaves identically to a plain string configfile
- Empty list is a no-op
- Missing file in chain returns a clear error naming the file
- CLI overrides every file in the chain
- \`HasValue\` tracking across overlay (field set by file 1 and not mentioned in file 2 still reports \`HasValue=true\`)
- Programmatic \`SetConfigFile\` on \`[]string\` fields
- Substruct chain + root file interaction (substruct loads first, root overlays)
- Public \`LoadConfigFiles\` helper: in-order overlay, empty-string skip, nil/empty no-op, first-missing-file error, use inside \`PreValidateFunc\`

Updated \`TestProgrammaticSetConfigFile_NonStringRejected\` to match the new error message.

## Docs

- \`docs/examples-config.md\` — new \"Multi-File Overlay\" section with full example (base + local cascade) and \`LoadConfigFiles\` helper.
- \`docs/advanced.md\` — new \"Multi-File Overlay Chains\" subsection under config file loading, cross-links to examples.

## Test plan
- [x] \`go test ./...\` — all green
- [x] \`go vet ./...\` — clean
- [x] Existing single-string configfile tests still pass (no behavior change)
- [x] New multi-file tests exercise tag-driven, programmatic, public helper, substruct-interaction paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-file configuration overlay: declare a config file field as a list to apply left-to-right overlays where later files override earlier keys; collections are replaced, empty entries are skipped, and missing files produce an error naming the failed file.
  * Added a helper to load ordered config-file lists programmatically.

* **Documentation**
  * Expanded docs and examples showing overlay semantics, precedence with CLI/env, and runtime usage.

* **Tests**
  * New tests covering overlay behavior, error cases, and precedence interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->