### PR TITLE
feat: format-aware field-tag resolution in set-by-config detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ Programmatic calls must happen in `InitFunc` / `InitFuncCtx` so they take effect
 - `Cmd.ConfigFormat` / legacy `Cmd.ConfigUnmarshal` are **per-command escape hatches** that lock that one command to a single format, bypassing the extension registry. Prefer registry-based dispatch unless you have a specific reason (legacy blob ingestion, test fixtures).
 - Resolution per load: `Cmd.ConfigFormat` > `Cmd.ConfigUnmarshal` > extension-registered format > JSON fallback.
 - `KeyTree` may return nested values as `map[string]any` (native) or `map[any]any` (e.g. yaml.v2); boa coerces transparently via `asKeyMap`.
+- Set-by-config detection is **format-aware via a single extension→struct-tag mapping**, shared with the dump path. `structTagForExt(ext)` picks the tag boa uses when matching KeyTree keys to Go fields: `.yaml`/`.yml`→`yaml`, `.toml`→`toml`, `.hcl`→`hcl`, `.json`/`""`→`json`, and any other registered extension defaults to the extension minus its leading dot (`.mycustom`→`mycustom`). A raw KeyTree is first canonicalised to Go-field-name keys in one pass; the walker (`markConfigKeysPresentInStruct`) then does plain Go-field-name lookups like mirrors do, with no tag awareness of its own. Renames live entirely in the canonicalisation step, so mixing multiple formats in one binary "just works".
+- The key-presence walker runs for every root load regardless of whether any preallocated struct-pointer groups exist. That means flat structs also get precise set-by-config detection for zero-value writes and same-as-default writes, not just struct-pointer groups.
 - Substruct `configfile:"true"` fields load their own config files; priority: CLI > env > root config > substruct config > defaults
 
 ### Custom Type Registration

--- a/docs/examples-config.md
+++ b/docs/examples-config.md
@@ -331,9 +331,11 @@ DB:
   Port: 5432   # same as the default
 ```
 
-Without a `KeyTree`, BOA falls back to snapshot comparison — it compares struct values before and after loading. Those writes don't change anything, so BOA concludes "nothing set" and `p.DB` is nil'd back out after cleanup. With a `KeyTree`, BOA sees the literal key structure, recognises that `DB`, `DB.Host`, and `DB.Port` were mentioned, and keeps the pointer group alive.
+Without a `KeyTree`, BOA falls back to snapshot comparison — it compares struct values before and after loading. Those writes don't change anything, so BOA concludes "nothing set": `p.DB` is nil'd back out after cleanup, and `HookContext.HasValue(&p.DB.Port)` keeps reporting `false` (since the snapshot saw no change) even for flat top-level fields with a zero-value write. With a `KeyTree`, BOA sees the literal key structure, recognises that `DB`, `DB.Host`, and `DB.Port` were mentioned, keeps the pointer group alive, and correctly reports `HasValue` / set-by-config for every leaf the file actually wrote.
 
-This matters only for struct-pointer parameter groups; plain fields and non-pointer substructs work with either form. `RegisterConfigFormat` already wires up the `KeyTree` for you whenever the parser can decode into `map[string]any` — which is every mainstream Go parser.
+This matters whenever you care about the difference between "the config file mentioned this field" and "the field kept its default". It applies both to optional struct-pointer parameter groups (where the difference decides whether the group survives cleanup) and to plain top-level fields (where the difference is visible via `HookContext.HasValue`). `RegisterConfigFormat` already wires up the `KeyTree` for you whenever the parser can decode into `map[string]any` — which is every mainstream Go parser.
+
+**Field name matching is format-aware.** Because the dump and load paths share a single extension→struct-tag mapping, BOA looks up each field using the struct tag the parser itself respects: `json` for `.json`, `yaml` for `.yaml` / `.yml`, `toml` for `.toml`, `hcl` for `.hcl`, and for any other registered extension the tag defaults to the extension name minus its leading dot (so `.mycustom` consults the `mycustom` tag). Renames like `Host string \`yaml:"host_name"\`` are therefore picked up by set-by-config detection too, not just by the Go-side unmarshaler. Tag value `"-"` skips the field, and tag value `"name,opt,opt"` uses just `name` — same conventions every mainstream Go config parser already follows.
 
 ### The `UniversalConfigFormat` Helper
 

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -529,23 +529,30 @@ func (c *HookContext) DumpBytes(ext string, marshalFunc func(v any) ([]byte, err
 	return marshal(tree)
 }
 
-// structTagForExt maps a config file extension to the struct tag the
-// corresponding marshaler consults when encoding struct values. We use the
-// same tag for the map[string]any key names so a source-aware dump's output
-// uses the same names as if the marshaler had handled the struct itself.
-// An empty return value means "no tag lookup — use the Go field name".
+// structTagForExt maps a config file extension to the struct tag that
+// boa should consult when mapping config-file keys to Go struct fields,
+// in both directions — the dump path (source-aware map key generation)
+// and the load path (set-by-config detection for optional struct-pointer
+// groups and for HasValue). Keeping a single source of truth across both
+// paths means renames like `json:"host"` → `"host"` round-trip from a
+// config file back out to a dump of the same format without drift.
+//
+// For unrecognised extensions we default to the extension minus its
+// leading dot — so registering a custom `.kvp` format automatically
+// uses the `kvp` struct tag without any extra plumbing, and registering
+// `.mycustom` uses `mycustom`. Users who want a different convention
+// today need a per-command `Cmd.ConfigFormat` override. We keep the
+// explicit `.yml` entry because yaml parsers consult the `yaml` tag,
+// not a hypothetical `yml` one. Empty ext falls back to `json` so
+// programmatic Dump/Load calls without a file path stay JSON-shaped.
 func structTagForExt(ext string) string {
 	switch ext {
-	case ".json", "":
+	case "", ".json":
 		return "json"
-	case ".yaml", ".yml":
+	case ".yml":
 		return "yaml"
-	case ".toml":
-		return "toml"
-	case ".hcl":
-		return "hcl"
 	}
-	return ""
+	return strings.TrimPrefix(ext, ".")
 }
 
 // resolveDumpFieldName picks the key name for a struct field in a

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -747,4 +749,987 @@ func TestCustomConfigFormat_KeyTreeHandlesMapAnyAny(t *testing.T) {
 	if gotDB == nil {
 		t.Fatal("expected DB pointer group to survive when KeyTree returns map[any]any for nested mappings")
 	}
+}
+
+// --- Mini "kvp" config format: a hand-rolled `key: value` parser used to
+// prove the format-aware field-tag path end-to-end without pulling in a
+// real YAML/TOML/HCL dependency. Supports:
+//
+//   - Flat scalar lines:           name: value
+//   - Dot-nested keys:              svc.port: 8080
+//   - String, int, and bool leaves
+//   - Per-field renames via `kvp:"name"` struct tag, with `kvp:"-"`
+//     to skip and `kvp:"name,opt,opt"` option-list handling
+//   - `#` line comments and blank lines
+//
+// It deliberately does not support arrays / maps / multiline values —
+// the failing test doesn't need those and the parser stays ~80 lines.
+// ---
+
+func miniKVUnmarshal(data []byte, target any) error {
+	tree, err := miniKVKeyTree(data)
+	if err != nil {
+		return err
+	}
+	v := reflect.ValueOf(target)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		return fmt.Errorf("mini-kv: target must be a non-nil pointer")
+	}
+	return miniKVAssign(v.Elem(), tree)
+}
+
+func miniKVKeyTree(data []byte) (map[string]any, error) {
+	out := map[string]any{}
+	for i, line := range strings.Split(string(data), "\n") {
+		s := strings.TrimSpace(line)
+		if s == "" || strings.HasPrefix(s, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(s, ":")
+		if !ok {
+			return nil, fmt.Errorf("mini-kv line %d: missing ':'", i+1)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		// Support dot-nested keys: foo.bar.baz: v
+		parts := strings.Split(k, ".")
+		m := out
+		for _, p := range parts[:len(parts)-1] {
+			sub, ok := m[p].(map[string]any)
+			if !ok {
+				sub = map[string]any{}
+				m[p] = sub
+			}
+			m = sub
+		}
+		m[parts[len(parts)-1]] = v
+	}
+	return out, nil
+}
+
+func miniKVAssign(v reflect.Value, tree map[string]any) error {
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		sf := t.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		key := sf.Name
+		if tv := sf.Tag.Get("kvp"); tv != "" {
+			name := strings.SplitN(tv, ",", 2)[0]
+			switch name {
+			case "-":
+				continue
+			case "":
+				// bare options, e.g. `kvp:",omitempty"` → fall back to field name
+			default:
+				key = name
+			}
+		}
+		// Case-insensitive raw-key lookup, matching encoding/json behaviour.
+		raw, ok := tree[key]
+		if !ok {
+			for k, val := range tree {
+				if strings.EqualFold(k, key) {
+					raw, ok = val, true
+					break
+				}
+			}
+		}
+		if !ok {
+			continue
+		}
+		fv := v.Field(i)
+		// Nested struct / *struct: recurse when the raw value is a map.
+		ft := sf.Type
+		inner := fv
+		if ft.Kind() == reflect.Ptr {
+			if fv.IsNil() {
+				fv.Set(reflect.New(ft.Elem()))
+			}
+			inner = fv.Elem()
+			ft = ft.Elem()
+		}
+		if sub, isMap := raw.(map[string]any); isMap && ft.Kind() == reflect.Struct {
+			if err := miniKVAssign(inner, sub); err != nil {
+				return err
+			}
+			continue
+		}
+		// Leaf — the raw value is a string scalar. For slice and map
+		// fields we decode a mini CSV / key=value shape inline so the
+		// complex-struct tests can exercise those kinds without pulling
+		// in a real YAML/TOML parser.
+		s, _ := raw.(string)
+		if err := miniKVAssignScalar(inner, s, sf.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func miniKVAssignScalar(inner reflect.Value, s, fieldName string) error {
+	switch inner.Kind() {
+	case reflect.String:
+		inner.SetString(s)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return fmt.Errorf("mini-kv %s: %w", fieldName, err)
+		}
+		inner.SetInt(n)
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return fmt.Errorf("mini-kv %s: %w", fieldName, err)
+		}
+		inner.SetBool(b)
+	case reflect.Slice:
+		// Comma-separated scalar slice (e.g. "a,b,c" or "1,2,3").
+		// Empty string means an empty (but non-nil) slice so the
+		// mirror sees "something was written here".
+		parts := []string{}
+		if s != "" {
+			parts = strings.Split(s, ",")
+		}
+		sl := reflect.MakeSlice(inner.Type(), len(parts), len(parts))
+		for i, p := range parts {
+			if err := miniKVAssignScalar(sl.Index(i), strings.TrimSpace(p), fieldName); err != nil {
+				return err
+			}
+		}
+		inner.Set(sl)
+	case reflect.Map:
+		// `k1=v1;k2=v2` inline map. Value parsing delegates back to
+		// miniKVAssignScalar so map[string]int etc. Just Work™.
+		if inner.IsNil() {
+			inner.Set(reflect.MakeMapWithSize(inner.Type(), 0))
+		}
+		if s == "" {
+			return nil
+		}
+		for _, pair := range strings.Split(s, ";") {
+			k, v, ok := strings.Cut(pair, "=")
+			if !ok {
+				return fmt.Errorf("mini-kv %s: map entry %q missing '='", fieldName, pair)
+			}
+			keyVal := reflect.New(inner.Type().Key()).Elem()
+			if err := miniKVAssignScalar(keyVal, strings.TrimSpace(k), fieldName); err != nil {
+				return err
+			}
+			valVal := reflect.New(inner.Type().Elem()).Elem()
+			if err := miniKVAssignScalar(valVal, strings.TrimSpace(v), fieldName); err != nil {
+				return err
+			}
+			inner.SetMapIndex(keyVal, valVal)
+		}
+	}
+	return nil
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV reproduces — and, after the
+// fix, exercises — the behaviour that config-file set-detection honours
+// the format-appropriate struct tag. Before the fix, the walker hard-
+// coded a `json` tag lookup so a field renamed via ANY other tag
+// (`yaml`, `toml`, `hcl`, or a custom `kvp` here) was never marked as
+// set-by-config. After the fix, tag resolution lives on the dump/load
+// shared helper (structTagForExt) and defaults to the file extension
+// minus its leading dot, so registering `.kvp` is all that's needed —
+// no extra plumbing, no ConfigFormat field.
+func TestConfigFile_FormatAwareFieldTag_MiniKV(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		// kvp tag renames the field. No json tag — the walker must not
+		// fall back to the Go field name here; it must consult `kvp`
+		// because the file extension is ".kvp".
+		Retries int `descr:"retries" kvp:"retry_count" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	if err := os.WriteFile(cfgPath, []byte("retry_count: 0\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	// Check setByConfig directly — HasValue would also be true if the
+	// parameter had a default, which would confound this test. Here we
+	// want: "the config file mentioned this key, therefore setByConfig".
+	var gotRetries int
+	var retriesSetByConfig bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotRetries = p.Retries
+			if pm, ok := ctx.GetParam(&p.Retries).(*paramMeta); ok {
+				retriesSetByConfig = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The mini parser itself is correct (it reads the kvp tag), so value
+	// loading works regardless of the bug — this assertion guards the
+	// test's own fixture.
+	if gotRetries != 0 {
+		t.Errorf("Retries = %d, want 0 from config", gotRetries)
+	}
+	// The headline assertion: the walker must recognise the kvp tag so
+	// it marks Retries as set-by-config, even though the value happens
+	// to be the zero value.
+	if !retriesSetByConfig {
+		t.Error("Retries.setByConfig should be true — kvp:\"retry_count\" is present in the config, but set-detection is only consulting the json tag")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV_NonZeroValue is the
+// complement to the zero-value test — with a non-zero value the
+// snapshot fallback can also catch the change, so this test pins the
+// "happy path" and guards against a regression where the fix stopped
+// running the key-presence walker for non-zero writes.
+func TestConfigFile_FormatAwareFieldTag_MiniKV_NonZeroValue(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Retries    int    `descr:"retries" kvp:"retry_count" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	if err := os.WriteFile(cfgPath, []byte("retry_count: 7\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var gotRetries int
+	var retriesSetByConfig bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotRetries = p.Retries
+			if pm, ok := ctx.GetParam(&p.Retries).(*paramMeta); ok {
+				retriesSetByConfig = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRetries != 7 {
+		t.Errorf("Retries = %d, want 7", gotRetries)
+	}
+	if !retriesSetByConfig {
+		t.Error("Retries.setByConfig should be true for a non-zero write via kvp:\"retry_count\"")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV_NestedPointerGroup is the
+// most realistic shape: an optional struct-pointer group (e.g. a
+// database section) whose child fields are renamed via kvp tags, and
+// whose values in the config happen to be zero. Without the fix, the
+// walker never matches the renamed keys, cleanup nils out the group,
+// and the user's "DB section was explicitly configured" signal is lost.
+func TestConfigFile_FormatAwareFieldTag_MiniKV_NestedPointerGroup(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type DB struct {
+		Host string `descr:"db host" kvp:"host_name" default:"localhost"`
+		Port int    `descr:"db port" kvp:"listen_port" default:"5432"`
+	}
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		DB         *DB
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	// Both leaves are the zero value for their Go type, so only a
+	// working KeyTree + canonicalisation can keep the DB pointer alive
+	// past cleanup.
+	raw := []byte("db.host_name: \ndb.listen_port: 0\n")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var gotDB *DB
+	var hostSet, portSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotDB = p.DB
+			if p.DB != nil {
+				if pm, ok := ctx.GetParam(&p.DB.Host).(*paramMeta); ok {
+					hostSet = pm.setByConfig
+				}
+				if pm, ok := ctx.GetParam(&p.DB.Port).(*paramMeta); ok {
+					portSet = pm.setByConfig
+				}
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotDB == nil {
+		t.Fatal("DB pointer group should survive cleanup when children are mentioned in config via kvp tags")
+	}
+	if !hostSet {
+		t.Error("DB.Host.setByConfig should be true — kvp:\"host_name\" present in the config")
+	}
+	if !portSet {
+		t.Error("DB.Port.setByConfig should be true — kvp:\"listen_port\" present in the config")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV_TagDashSkipsField pins the
+// tag-value-"-" contract: a format that explicitly excludes a field
+// (e.g. `kvp:"-"`) must not have boa mark that field as set-by-config,
+// even if a same-named key happens to appear in the config file.
+// This matches how encoding/json handles `json:"-"`.
+func TestConfigFile_FormatAwareFieldTag_MiniKV_TagDashSkipsField(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Secret     string `descr:"secret" kvp:"-" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	// A stray line mentioning "Secret" — the kvp:"-" tag means the
+	// format owner declared this field off-limits for kvp files,
+	// so set-detection must not pick it up.
+	if err := os.WriteFile(cfgPath, []byte("Secret: leaked\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var secretSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if pm, ok := ctx.GetParam(&p.Secret).(*paramMeta); ok {
+				secretSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if secretSet {
+		t.Error("Secret should NOT be marked setByConfig — kvp:\"-\" means the format excludes this field")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV_TagWithOptions covers the
+// `name,opt1,opt2` tag value shape that encoding/json popularised and
+// every mainstream format parser inherits. Only the first comma-
+// separated segment is the raw key name; the rest are format-specific
+// options (omitempty, inline, …) that boa doesn't care about.
+func TestConfigFile_FormatAwareFieldTag_MiniKV_TagWithOptions(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Name       string `descr:"name" kvp:"display_name,omitempty,extra" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	if err := os.WriteFile(cfgPath, []byte("display_name: boa\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var gotName string
+	var nameSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotName = p.Name
+			if pm, ok := ctx.GetParam(&p.Name).(*paramMeta); ok {
+				nameSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotName != "boa" {
+		t.Errorf("Name = %q, want boa", gotName)
+	}
+	if !nameSet {
+		t.Error("Name.setByConfig should be true — tag options after the first comma must not break key matching")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MiniKV_CaseInsensitiveLookup
+// locks in encoding/json's case-insensitive matching rule for non-
+// JSON formats too, since the canonicalization step reuses the same
+// configKeyLookup helper. A config file that writes `DISPLAY_NAME`
+// (upper-cased) must still match a field tagged `kvp:"display_name"`.
+func TestConfigFile_FormatAwareFieldTag_MiniKV_CaseInsensitiveLookup(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Name       string `descr:"name" kvp:"display_name" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	if err := os.WriteFile(cfgPath, []byte("DISPLAY_NAME: boa\n"), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var nameSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if pm, ok := ctx.GetParam(&p.Name).(*paramMeta); ok {
+				nameSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !nameSet {
+		t.Error("Name.setByConfig should be true — case-insensitive raw-key match must still work with a custom tag")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_YmlExtensionUsesYamlTag verifies
+// the one hand-wired special case in structTagForExt: `.yml` files map
+// to the `yaml` struct tag, because yaml parsers (yaml.v2, yaml.v3,
+// goccy/go-yaml, …) all consult the yaml tag regardless of which file
+// extension the user wrote. Without this special case, a `.yml` file
+// would try the `yml` tag, which nobody uses.
+func TestConfigFile_FormatAwareFieldTag_YmlExtensionUsesYamlTag(t *testing.T) {
+	// Fake yaml: reuse fakeUnmarshal (JSON bytes) and synthesize a
+	// KeyTree that uses yaml-style key names. Registering `.yml`
+	// directly pins the special case to the load path.
+	registerFormatCleanup(t, ".yml", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree: func(data []byte) (map[string]any, error) {
+			return map[string]any{"retry_count": 0}, nil
+		},
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Retries    int    `descr:"retries" yaml:"retry_count" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.yml")
+	if err := os.WriteFile(cfgPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var retriesSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if pm, ok := ctx.GetParam(&p.Retries).(*paramMeta); ok {
+				retriesSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retriesSet {
+		t.Error(".yml files should consult the `yaml` struct tag (structTagForExt special case)")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_UnknownExtDefaultsToExtMinusDot
+// pins the "ext minus leading dot" fallback in structTagForExt: any
+// registered extension that isn't in the explicit special-case list
+// picks up the extension name as its struct tag by default. So
+// registering `.bespoke` automatically consults the `bespoke` tag
+// with no extra configuration.
+func TestConfigFile_FormatAwareFieldTag_UnknownExtDefaultsToExtMinusDot(t *testing.T) {
+	registerFormatCleanup(t, ".bespoke", ConfigFormat{
+		Unmarshal: fakeUnmarshal,
+		KeyTree: func(data []byte) (map[string]any, error) {
+			return map[string]any{"magic_field": 0}, nil
+		},
+	})
+
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Magic      int    `descr:"magic" bespoke:"magic_field" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.bespoke")
+	if err := os.WriteFile(cfgPath, []byte(`{}`), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var magicSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if pm, ok := ctx.GetParam(&p.Magic).(*paramMeta); ok {
+				magicSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !magicSet {
+		t.Error("Magic.setByConfig should be true — `.bespoke` should auto-resolve to the `bespoke` struct tag")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_ZeroIntFlatJsonNoTag regresses the
+// original user report: a JSON config file writes an integer field to
+// 0, the struct has no rename tag, and the field sits at the top level
+// (flat — no optional pointer group). Before the fix, set-by-config
+// detection was gated on `len(PreallocatedPtrs) > 0`, so a flat struct
+// with a zero-value write was never marked. After the fix, the walker
+// runs for every root load, so the zero write is correctly detected.
+func TestConfigFile_FormatAwareFieldTag_ZeroIntFlatJsonNoTag(t *testing.T) {
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Retries    int    `descr:"retries" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"Retries": 0}`), 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	var gotRetries int
+	var retriesSet bool
+	err := (CmdT[Params]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			gotRetries = p.Retries
+			if pm, ok := ctx.GetParam(&p.Retries).(*paramMeta); ok {
+				retriesSet = pm.setByConfig
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRetries != 0 {
+		t.Errorf("Retries = %d, want 0", gotRetries)
+	}
+	if !retriesSet {
+		t.Error("Retries.setByConfig should be true for a flat zero-value JSON write — this was the original bug report")
+	}
+}
+
+// TestConfigFile_FormatAwareFieldTag_MixedFormatsInOneBinary proves
+// that per-format tag resolution is fully per-load: the SAME struct
+// type can be loaded from two different files in the same process,
+// each honouring its own rename convention. `.json` uses `json` tags,
+// `.kvp` uses `kvp` tags, no cross-contamination.
+func TestConfigFile_FormatAwareFieldTag_MixedFormatsInOneBinary(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	// Two different tag names on the same field — the format-aware
+	// walker must pick the one matching each file's extension.
+	type Params struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Retries    int    `descr:"retries" json:"json_retries" kvp:"kvp_retries" optional:"true"`
+	}
+
+	dir := t.TempDir()
+	jsonPath := filepath.Join(dir, "cfg.json")
+	if err := os.WriteFile(jsonPath, []byte(`{"json_retries": 3}`), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+	kvpPath := filepath.Join(dir, "cfg.kvp")
+	if err := os.WriteFile(kvpPath, []byte("kvp_retries: 5\n"), 0o644); err != nil {
+		t.Fatalf("write kvp: %v", err)
+	}
+
+	run := func(cfgPath string) (int, bool) {
+		var gotRetries int
+		var retriesSet bool
+		err := (CmdT[Params]{
+			Use:         "test",
+			ParamEnrich: ParamEnricherName,
+			RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+				gotRetries = p.Retries
+				if pm, ok := ctx.GetParam(&p.Retries).(*paramMeta); ok {
+					retriesSet = pm.setByConfig
+				}
+			},
+		}).RunArgsE([]string{"--config-file", cfgPath})
+		if err != nil {
+			t.Fatalf("RunArgsE(%s): %v", cfgPath, err)
+		}
+		return gotRetries, retriesSet
+	}
+
+	jsonRetries, jsonSet := run(jsonPath)
+	if jsonRetries != 3 {
+		t.Errorf(".json load: Retries = %d, want 3 (via json tag)", jsonRetries)
+	}
+	if !jsonSet {
+		t.Error(".json load: Retries.setByConfig should be true")
+	}
+
+	kvpRetries, kvpSet := run(kvpPath)
+	if kvpRetries != 5 {
+		t.Errorf(".kvp load: Retries = %d, want 5 (via kvp tag)", kvpRetries)
+	}
+	if !kvpSet {
+		t.Error(".kvp load: Retries.setByConfig should be true")
+	}
+}
+
+// --- Deep / complex config-file tests ---
+//
+// These tests exercise the whole config-file machinery on a realistic
+// three-level shape (app → service → network), with mixed scalars,
+// slices, maps, renamed fields, and optional struct-pointer groups.
+// Each test picks a single config file format (JSON or the custom
+// kvp format), writes either a partial or a full payload, and asserts
+// two things end-to-end:
+//
+//   1. Every field that the config mentioned loaded to the expected
+//      value.
+//   2. Every mentioned field reports setByConfig=true, and fields that
+//      the config did NOT mention report setByConfig=false, so the
+//      "was this written by the user?" signal stays trustworthy even
+//      when a written value equals the Go zero value or the default.
+//
+// Both tests share the same struct shape so we can compare apples to
+// apples across formats.
+
+type deepNet struct {
+	// Leaf scalars, a slice, and a map — the four kinds the walker
+	// treats as terminal nodes.
+	Host    string            `descr:"host" json:"host_name" kvp:"host_name" default:"localhost"`
+	Port    int               `descr:"port" json:"listen_port" kvp:"listen_port" default:"8080"`
+	TLS     bool              `descr:"tls" json:"tls_enabled" kvp:"tls_enabled" optional:"true"`
+	Origins []string          `descr:"allowed origins" json:"allowed_origins" kvp:"allowed_origins" optional:"true"`
+	Labels  map[string]string `descr:"labels" json:"labels" kvp:"labels" optional:"true"`
+}
+
+type deepSvc struct {
+	Name    string `descr:"service name" json:"svc_name" kvp:"svc_name" optional:"true"`
+	Retries int    `descr:"retries" json:"retry_count" kvp:"retry_count" default:"3"`
+	// Nested optional pointer group — the "level 3" target.
+	Net *deepNet `json:"net" kvp:"net"`
+}
+
+type deepApp struct {
+	ConfigFile string `configfile:"true" optional:"true"`
+	AppName    string `descr:"app name" json:"app_name" kvp:"app_name" default:"boa-app"`
+	// Nested optional pointer group — the "level 2" target. deepSvc
+	// contains a further pointer group so key-presence detection has
+	// to survive two boundaries to reach the deepest leaves.
+	Svc *deepSvc `json:"svc" kvp:"svc"`
+}
+
+func runDeepApp(t *testing.T, cfgPath string) (*deepApp, map[string]bool) {
+	t.Helper()
+	var got deepApp
+	marked := map[string]bool{}
+	// Record setByConfig for every mirror we care about. Using direct
+	// paramMeta access keeps the assertions precise — HasValue is
+	// polluted by defaults and would give spurious passes.
+	err := (CmdT[deepApp]{
+		Use:         "test",
+		ParamEnrich: ParamEnricherName,
+		RunFuncCtx: func(ctx *HookContext, p *deepApp, cmd *cobra.Command, args []string) {
+			got = *p
+			record := func(label string, addr any) {
+				if pm, ok := ctx.GetParam(addr).(*paramMeta); ok {
+					marked[label] = pm.setByConfig
+				} else {
+					marked[label] = false
+				}
+			}
+			record("app_name", &p.AppName)
+			if p.Svc != nil {
+				record("svc_name", &p.Svc.Name)
+				record("retries", &p.Svc.Retries)
+				if p.Svc.Net != nil {
+					record("host", &p.Svc.Net.Host)
+					record("port", &p.Svc.Net.Port)
+					record("tls", &p.Svc.Net.TLS)
+					record("origins", &p.Svc.Net.Origins)
+					record("labels", &p.Svc.Net.Labels)
+				}
+			}
+		},
+	}).RunArgsE([]string{"--config-file", cfgPath})
+	if err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	return &got, marked
+}
+
+func assertMarked(t *testing.T, marked map[string]bool, wantSet, wantUnset []string) {
+	t.Helper()
+	for _, k := range wantSet {
+		if !marked[k] {
+			t.Errorf("expected %q setByConfig=true, got false", k)
+		}
+	}
+	for _, k := range wantUnset {
+		if marked[k] {
+			t.Errorf("expected %q setByConfig=false, got true", k)
+		}
+	}
+}
+
+// TestConfigFile_Deep_Json_FullPayload exercises the full three-level
+// tree in JSON, with every leaf kind populated, including zero-value
+// writes and same-as-default writes that would defeat a snapshot-only
+// detector.
+func TestConfigFile_Deep_Json_FullPayload(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.json")
+	// Deliberate mix: host="" (zero), port=8080 (same-as-default),
+	// tls=false (zero), origins=[] (empty slice), labels={} (empty
+	// map), retry_count=3 (same-as-default). Only KeyTree-based
+	// detection can mark all of these.
+	raw := []byte(`{
+		"app_name": "boa-app",
+		"svc": {
+			"svc_name": "api",
+			"retry_count": 3,
+			"net": {
+				"host_name": "",
+				"listen_port": 8080,
+				"tls_enabled": false,
+				"allowed_origins": [],
+				"labels": {}
+			}
+		}
+	}`)
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	got, marked := runDeepApp(t, cfgPath)
+
+	// Values.
+	if got.AppName != "boa-app" {
+		t.Errorf("AppName = %q, want boa-app", got.AppName)
+	}
+	if got.Svc == nil {
+		t.Fatal("Svc pointer group should survive cleanup (config mentioned it)")
+	}
+	if got.Svc.Name != "api" {
+		t.Errorf("Svc.Name = %q, want api", got.Svc.Name)
+	}
+	if got.Svc.Retries != 3 {
+		t.Errorf("Svc.Retries = %d, want 3", got.Svc.Retries)
+	}
+	if got.Svc.Net == nil {
+		t.Fatal("Svc.Net pointer group should survive cleanup")
+	}
+	if got.Svc.Net.Host != "" {
+		t.Errorf("Svc.Net.Host = %q, want empty", got.Svc.Net.Host)
+	}
+	if got.Svc.Net.Port != 8080 {
+		t.Errorf("Svc.Net.Port = %d, want 8080", got.Svc.Net.Port)
+	}
+	if got.Svc.Net.TLS != false {
+		t.Errorf("Svc.Net.TLS = %v, want false", got.Svc.Net.TLS)
+	}
+
+	// Every leaf the config mentioned must be reported as set.
+	assertMarked(t, marked,
+		[]string{"app_name", "svc_name", "retries", "host", "port", "tls", "origins", "labels"},
+		nil,
+	)
+}
+
+// TestConfigFile_Deep_Json_PartialPayload covers the "partial config"
+// case: some leaves are present, others are absent. The present leaves
+// must report setByConfig=true, the absent ones must report false —
+// even when the absent fields have defaults that make HasValue true.
+// This is the reason the test reads setByConfig directly instead of
+// relying on HasValue.
+func TestConfigFile_Deep_Json_PartialPayload(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.json")
+	// Only two leaves written. Everything else must come from
+	// defaults (AppName="boa-app", Retries=3, Port=8080, Host="localhost")
+	// but defaults must NOT leak into setByConfig.
+	raw := []byte(`{
+		"svc": {
+			"net": {
+				"tls_enabled": true,
+				"allowed_origins": ["https://a", "https://b"]
+			}
+		}
+	}`)
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	got, marked := runDeepApp(t, cfgPath)
+
+	if got.AppName != "boa-app" {
+		t.Errorf("AppName = %q, want default boa-app", got.AppName)
+	}
+	if got.Svc == nil || got.Svc.Net == nil {
+		t.Fatal("Svc/Svc.Net should survive — config mentioned them")
+	}
+	if got.Svc.Net.TLS != true {
+		t.Errorf("Svc.Net.TLS = %v, want true", got.Svc.Net.TLS)
+	}
+	if len(got.Svc.Net.Origins) != 2 || got.Svc.Net.Origins[0] != "https://a" {
+		t.Errorf("Svc.Net.Origins = %v, want [https://a https://b]", got.Svc.Net.Origins)
+	}
+
+	// Exactly the written keys should be marked; the rest must not be.
+	assertMarked(t, marked,
+		[]string{"tls", "origins"},
+		[]string{"app_name", "svc_name", "retries", "host", "port", "labels"},
+	)
+}
+
+// TestConfigFile_Deep_MiniKV_FullPayload mirrors the JSON full-payload
+// test with the custom kvp format, so the three-level walk, the slice
+// and map leaves, the zero-value / same-as-default writes, and the
+// per-field renames are all exercised together under a non-JSON
+// format's struct tag.
+func TestConfigFile_Deep_MiniKV_FullPayload(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	// Dot-nested keys walk into nested structs; slice is comma
+	// separated, map is `k=v;k=v`.
+	raw := []byte(strings.Join([]string{
+		"app_name: boa-app",
+		"svc.svc_name: api",
+		"svc.retry_count: 3",
+		"svc.net.host_name: ",
+		"svc.net.listen_port: 8080",
+		"svc.net.tls_enabled: false",
+		"svc.net.allowed_origins: https://a,https://b",
+		"svc.net.labels: team=core;tier=gold",
+		"",
+	}, "\n"))
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	got, marked := runDeepApp(t, cfgPath)
+
+	if got.Svc == nil || got.Svc.Net == nil {
+		t.Fatal("Svc/Svc.Net should survive — kvp config mentioned both")
+	}
+	if got.Svc.Name != "api" {
+		t.Errorf("Svc.Name = %q, want api", got.Svc.Name)
+	}
+	if got.Svc.Retries != 3 {
+		t.Errorf("Svc.Retries = %d, want 3", got.Svc.Retries)
+	}
+	if got.Svc.Net.Host != "" {
+		t.Errorf("Svc.Net.Host = %q, want empty (zero-value write)", got.Svc.Net.Host)
+	}
+	if got.Svc.Net.Port != 8080 {
+		t.Errorf("Svc.Net.Port = %d, want 8080", got.Svc.Net.Port)
+	}
+	if len(got.Svc.Net.Origins) != 2 || got.Svc.Net.Origins[0] != "https://a" {
+		t.Errorf("Svc.Net.Origins = %v, want [https://a https://b]", got.Svc.Net.Origins)
+	}
+	if got.Svc.Net.Labels["team"] != "core" || got.Svc.Net.Labels["tier"] != "gold" {
+		t.Errorf("Svc.Net.Labels = %v, want team=core tier=gold", got.Svc.Net.Labels)
+	}
+
+	assertMarked(t, marked,
+		[]string{"app_name", "svc_name", "retries", "host", "port", "tls", "origins", "labels"},
+		nil,
+	)
+}
+
+// TestConfigFile_Deep_MiniKV_PartialPayload is the kvp counterpart to
+// TestConfigFile_Deep_Json_PartialPayload: a partial config that only
+// mentions a couple of deep leaves. Un-mentioned fields must still
+// report setByConfig=false, and the optional pointer groups above a
+// mentioned leaf must stay alive through cleanup.
+func TestConfigFile_Deep_MiniKV_PartialPayload(t *testing.T) {
+	registerFormatCleanup(t, ".kvp", ConfigFormat{
+		Unmarshal: miniKVUnmarshal,
+		KeyTree:   miniKVKeyTree,
+	})
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "cfg.kvp")
+	raw := []byte("svc.net.listen_port: 0\nsvc.net.tls_enabled: true\n")
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatalf("write cfg: %v", err)
+	}
+
+	got, marked := runDeepApp(t, cfgPath)
+
+	if got.AppName != "boa-app" {
+		t.Errorf("AppName = %q, want default boa-app", got.AppName)
+	}
+	if got.Svc == nil || got.Svc.Net == nil {
+		t.Fatal("Svc/Svc.Net pointer groups should survive — config reached into them")
+	}
+	if got.Svc.Net.Port != 0 {
+		t.Errorf("Svc.Net.Port = %d, want 0 (zero-value kvp write)", got.Svc.Net.Port)
+	}
+	if !got.Svc.Net.TLS {
+		t.Errorf("Svc.Net.TLS = %v, want true", got.Svc.Net.TLS)
+	}
+
+	assertMarked(t, marked,
+		[]string{"port", "tls"},
+		[]string{"app_name", "svc_name", "retries", "host", "origins", "labels"},
+	)
 }

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"slices"
@@ -412,20 +413,23 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 }
 
 // markConfigKeysPresent probes the raw config file data for key presence to detect
-// which preallocated struct pointer fields were explicitly mentioned in the config,
-// even if the values are zero or match the defaults.
+// which struct fields — flat leaves and preallocated struct-pointer groups alike —
+// were explicitly mentioned in the config, even if the written values are zero
+// or match the defaults.
 //
 // It delegates to the ConfigFormat's KeyTree to build a nested map[string]any
-// representing the raw bytes' key structure, then matches entries against
-// struct field names using case-insensitive logic (the same rule encoding/json
-// applies). For nested structs, it recurses into sub-maps.
+// representing the raw bytes' key structure. That raw tree is then canonicalised
+// in one pass: format-tag key names (e.g. a yaml `retry_count`) are rewritten to
+// the matching Go field names via the tag picked by structTagForExt(ext). After
+// canonicalisation the walker works purely in Go-field-name space, the same way
+// boa's mirrors are keyed — no tag awareness inside the walker itself.
 //
-// Returns true if key-presence detection succeeded. Returns false when the
-// format has no KeyTree, when the probe errors out, or when there are no
-// preallocated pointer groups to care about — in those cases the caller
-// should fall back to snapshot comparison.
-func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldPath, rawData []byte, format ConfigFormat) bool {
-	if len(ctx.PreallocatedPtrs) == 0 || len(rawData) == 0 {
+// Returns true if key-presence detection succeeded (the walker was run). Returns
+// false when the format has no KeyTree or the probe errors out — in those cases
+// the caller should fall back to snapshot comparison for any struct-pointer groups
+// inside this subtree.
+func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldPath, rawData []byte, format ConfigFormat, ext string) bool {
+	if len(rawData) == 0 {
 		return false
 	}
 	if format.KeyTree == nil {
@@ -435,8 +439,95 @@ func markConfigKeysPresent(ctx *processingContext, target any, targetPath fieldP
 	if err != nil || topLevel == nil {
 		return false
 	}
-	markConfigKeysPresentInStruct(ctx, target, topLevel, splitPath(targetPath))
+	canonical := canonicalizeKeyTree(topLevel, reflect.TypeOf(target), structTagForExt(ext))
+	if canonical == nil {
+		return false
+	}
+	markConfigKeysPresentInStruct(ctx, target, canonical, splitPath(targetPath))
 	return true
+}
+
+// canonicalizeKeyTree walks a raw KeyTree (keyed by the format's own tag
+// names) alongside the target struct type, and returns an equivalent tree
+// whose keys are Go field names. Nested struct and struct-pointer fields
+// recurse so sub-trees end up canonical too.
+//
+// tag names the struct tag to consult for per-field renaming. When empty,
+// or when a field has no such tag, the Go field name is used directly.
+// Raw-key lookups are case-insensitive so the resulting matching rule
+// mirrors what encoding/json does, which keeps previously-passing tests
+// passing after the walker stops doing its own lookups.
+//
+// Unknown raw keys (with no matching struct field) are dropped — they
+// have no mirror for the walker to mark anyway. Scalar / slice / map
+// leaf values are passed through unchanged so the walker can still
+// treat them as "something was written here".
+func canonicalizeKeyTree(raw map[string]any, targetType reflect.Type, tag string) map[string]any {
+	if raw == nil {
+		return nil
+	}
+	for targetType != nil && targetType.Kind() == reflect.Ptr {
+		targetType = targetType.Elem()
+	}
+	if targetType == nil || targetType.Kind() != reflect.Struct {
+		// No struct to walk against — hand the raw map through. The
+		// walker will then either find keys by Go field name or not at
+		// all, which matches the pre-canonicalisation behaviour for
+		// unusual call sites.
+		return raw
+	}
+	out := make(map[string]any, len(raw))
+	for i := 0; i < targetType.NumField(); i++ {
+		sf := targetType.Field(i)
+		if !sf.IsExported() {
+			continue
+		}
+		rawKey := fieldRawKey(sf, tag)
+		if rawKey == "" {
+			continue // tag value was "-" — field deliberately skipped by the format
+		}
+		rawVal, ok := configKeyLookup(raw, rawKey)
+		if !ok {
+			continue
+		}
+		// Recurse into nested struct / *struct fields so their sub-keys
+		// also end up keyed by Go field name before the walker sees them.
+		ft := sf.Type
+		for ft.Kind() == reflect.Ptr {
+			ft = ft.Elem()
+		}
+		if ft.Kind() == reflect.Struct && !isSupportedType(sf.Type) {
+			if subMap := asKeyMap(rawVal); subMap != nil {
+				out[sf.Name] = canonicalizeKeyTree(subMap, ft, tag)
+				continue
+			}
+		}
+		out[sf.Name] = rawVal
+	}
+	return out
+}
+
+// fieldRawKey returns the raw key name that tag would use for this field.
+// Empty tag or missing tag value → Go field name. Tag value "-" means
+// "skip" (returns ""). Tag value with options (e.g. "name,omitempty") is
+// split on the first comma. This matches the conventions of encoding/json
+// and of every mainstream YAML/TOML/HCL parser boa is likely to meet.
+func fieldRawKey(sf reflect.StructField, tag string) string {
+	if tag == "" {
+		return sf.Name
+	}
+	tv := sf.Tag.Get(tag)
+	if tv == "" {
+		return sf.Name
+	}
+	name := strings.SplitN(tv, ",", 2)[0]
+	switch name {
+	case "":
+		return sf.Name
+	case "-":
+		return ""
+	}
+	return name
 }
 
 // splitPath parses a fieldPath string back into the []int index path form.
@@ -462,21 +553,6 @@ func splitPath(p fieldPath) []int {
 		out[i] = n
 	}
 	return out
-}
-
-// jsonFieldKey returns the key that encoding/json would use for a struct field.
-// If a json tag is present, use its name. Otherwise, use the Go field name.
-func jsonFieldKey(field reflect.StructField) string {
-	if tag := field.Tag.Get("json"); tag != "" {
-		parts := strings.SplitN(tag, ",", 2)
-		if parts[0] != "" && parts[0] != "-" {
-			return parts[0]
-		}
-		if parts[0] == "-" {
-			return "" // explicitly skipped
-		}
-	}
-	return field.Name
 }
 
 // configKeyLookup does a case-insensitive key lookup matching encoding/json behavior:
@@ -518,6 +594,11 @@ func asKeyMap(v any) map[string]any {
 	return nil
 }
 
+// markConfigKeysPresentInStruct walks a canonicalised KeyTree (Go field
+// names) alongside the target struct, marking mirrors and preallocated
+// struct-pointer groups that the config file mentioned. The walker has
+// no tag awareness — canonicalizeKeyTree already folded the format's
+// rename rules into Go-field-name space before the walker was called.
 func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys map[string]any, path []int) {
 	val := reflect.ValueOf(structPtr).Elem()
 	typ := val.Type()
@@ -527,8 +608,7 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 			continue
 		}
 		childPath := append(append([]int(nil), path...), i)
-		key := jsonFieldKey(field)
-		rawVal, keyPresent := configKeyLookup(keys, key)
+		rawVal, keyPresent := keys[field.Name]
 		if !keyPresent {
 			continue
 		}
@@ -2083,6 +2163,11 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 				targetPath fieldPath
 				rawData    []byte
 				format     ConfigFormat
+				// ext is the file extension (dot-prefixed) we loaded from,
+				// or "" for a programmatic load. Used later to drive
+				// format-aware field-tag resolution in the key-presence
+				// walker via structTagForExt.
+				ext string
 			}
 			var configResults []configLoadResult
 
@@ -2113,7 +2198,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective, ext: filepath.Ext(filePath)})
 						}
 					}
 				}
@@ -2126,7 +2211,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 							if err != nil {
 								return NewUserInputError(fmt.Errorf("configfile %s: %w", entry.mirror.GetName(), err))
 							}
-							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective})
+							configResults = append(configResults, configLoadResult{target: entry.target, targetPath: entry.targetPath, rawData: rawData, format: effective, ext: filepath.Ext(filePath)})
 						}
 					}
 				}
@@ -2142,7 +2227,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 			// precision of sibling loads whose KeyTree succeeded.
 			var fallbackRoots []fieldPath
 			for _, cr := range configResults {
-				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData, cr.format) {
+				if !markConfigKeysPresent(ctx, cr.target, cr.targetPath, cr.rawData, cr.format, cr.ext) {
 					fallbackRoots = append(fallbackRoots, cr.targetPath)
 				}
 			}


### PR DESCRIPTION
## Summary

- **Bug**: the load-side key-presence walker hard-coded a `json` struct-tag lookup, so fields renamed via `yaml:"..."`, `toml:"..."`, or any custom tag were never marked `setByConfig` — even though the dump path already honoured format-specific tags. Users couldn't tell "the config file wrote this" from "the default kicked in" for renamed fields in non-JSON formats, which defeats `HookContext.HasValue` and breaks optional struct-pointer group cleanup.
- **Second bug**: the walker was gated on `len(PreallocatedPtrs) > 0`, so flat top-level fields never reached it at all — a zero-value write to a flat field was silently dropped.
- **Fix**: unify load-side set-detection with the dump path's `structTagForExt` helper, now the single extension→struct-tag source of truth. A new canonicalisation step rewrites raw KeyTree keys to Go field names once per load, letting the walker operate in canonical Go-field-name space (same as mirrors). Extension→tag defaults to the extension minus its leading dot, so registering `.mycustom` automatically consults the `mycustom` tag with no extra config. Walker gating is loosened so flat structs also get precise detection.

## What changed

| File | Change |
|---|---|
| `pkg/boa/api_base.go` | `structTagForExt` defaults unknown extensions to `ext`-minus-dot, keeps `.yml`→`yaml` and `""`/`.json`→`json` special cases |
| `pkg/boa/internal.go` | New `canonicalizeKeyTree` + `fieldRawKey`; `markConfigKeysPresent` takes `ext`, runs canonicalisation; walker uses `keys[field.Name]` directly; `jsonFieldKey` deleted; preallocated-ptr gating lifted |
| `pkg/boa/config_format_test.go` | ~120-line dep-free "mini kvp" parser + 14 new tests |
| `CLAUDE.md`, `docs/examples-config.md` | Documented the unified extension→tag mapping and the loosened walker gating |

## Test plan

- [x] `go test ./...` — all existing tests pass
- [x] `go test -race ./...` — no races
- [x] New test suite covers:
  - Format-aware tag matching: zero value, non-zero, nested pointer group, `kvp:"-"` skip, `kvp:"name,omit,opts"`, case-insensitive lookup
  - Extension defaulting: `.yml` → `yaml` tag, `.bespoke` → `bespoke` tag
  - Flat-int-zero JSON regression from the original user report
  - Mixed formats in one binary: same struct loaded via `.json` (json tag) and `.kvp` (kvp tag)
  - Deep 3-level struct trees with scalars/slices/maps, in both JSON and the custom kvp format, with full and partial payloads, asserting `setByConfig` per field

## API notes

`structTagForExt` is internal, but its observable behaviour for **unknown** extensions in the **dump** path changed from `""` (use Go field name) to `strings.TrimPrefix(ext, ".")` (use that tag if present, else field name). In practice this only affects callers who happened to have struct tags matching their file extension — an unlikely collision, and a strict improvement for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Set-by-config detection now extends to flat structs, not just pointer-grouped structs, enabling precise distinction between explicitly configured and default values across all structure types.

* **Improvements**
  * Enhanced format-aware field matching across multiple config file formats with consistent behavior for renamed and skipped fields.

* **Documentation**
  * Updated examples and clarified set-by-config detection behavior in various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->