### PR TITLE
feat: add boa.Reload[T] primitive for live config reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,51 @@ boa.RegisterConfigFormat(".toml", toml.Unmarshal)
 </details>
 
 <details>
+<summary><b>Live Config Reload</b></summary>
+
+For long-running programs, `boa.Reload[T](ctx)` re-reads every config file, re-applies precedence (CLI still wins), re-validates, and returns a **brand-new `*T`**. The struct you originally got in `RunFunc` is never touched — every reload is a fresh allocation, and callers swap the pointer (typically via `atomic.Pointer[T]`) only when they're ready. On any failure — parse error, validation failure, missing file — Reload returns `(nil, err)` and nothing else changes, so noisy triggers (fsnotify fires multiple events per save) are safe to wire directly.
+
+```go
+import (
+    "os"
+    "os/signal"
+    "sync/atomic"
+    "syscall"
+)
+
+var active atomic.Pointer[Params]
+
+boa.CmdT[Params]{
+    Use: "server",
+    RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+        active.Store(p)
+
+        sighup := make(chan os.Signal, 1)
+        signal.Notify(sighup, syscall.SIGHUP)
+        go func() {
+            for range sighup {
+                fresh, err := boa.Reload[Params](ctx)
+                if err != nil {
+                    log.Printf("reload rejected: %v", err) // old config still serving
+                    continue
+                }
+                active.Store(fresh)
+            }
+        }()
+
+        startServer()
+    },
+}.Run()
+```
+
+Readers elsewhere in the program just do `cfg := active.Load()` — lock-free, always-consistent snapshots. `ctx.WatchedConfigFiles()` returns the paths you should hand to your trigger (fsnotify, timer, etc.).
+
+**No fsnotify in core.** Wire your own trigger: SIGHUP, an admin HTTP endpoint, fsnotify, a timer. The primitive just answers "give me a fresh validated config now". A higher-level watcher subpackage is planned as a follow-up.
+
+See the [Live Config Reload](https://gigurra.github.io/boa/live-reload/) page for SIGHUP / HTTP / fsnotify / timer recipes, error semantics, and the atomic-pointer swap pattern.
+</details>
+
+<details>
 <summary><b>Struct Composition</b></summary>
 
 Named fields auto-prefix their children. Embedded fields stay flat:
@@ -455,4 +500,5 @@ boa.CmdT[Params]{
 - [Enrichers](https://gigurra.github.io/boa/enrichers/) — auto-derive flag names, env vars, short flags
 - [Error Handling](https://gigurra.github.io/boa/error-handling/) — Run() vs RunE() and error propagation
 - [Advanced](https://gigurra.github.io/boa/advanced/) — custom types, config format registry, viper-like discovery
+- [Live Config Reload](https://gigurra.github.io/boa/live-reload/) — re-read config without restart via `boa.Reload[T](ctx)`
 - [Cobra Interop](https://gigurra.github.io/boa/cobra-interop/) — access cobra primitives, migrate incrementally

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -394,95 +394,9 @@ JSON comes with both directions pre-registered (pretty-printed, 2-space indent, 
 
 ## Live Config Reload
 
-Long-running programs (servers, daemons, background workers) often want to re-read config without restarting. BOA ships a primitive for this: `boa.Reload[T](ctx) (*T, error)`. It re-runs the entire post-flag-parse pipeline — CLI → env → config files → defaults → validation — on a **freshly allocated** `*T` and returns it.
+For long-running programs that want to re-read config without restarting, BOA ships `boa.Reload[T](ctx) (*T, error)`. Every call allocates a brand-new `*T` and runs the full pipeline against it — the struct you originally received in `RunFunc` is never mutated. On success you get back the fresh snapshot to swap in (typically via `atomic.Pointer[T]`). On any failure — parse error, validation failure, missing file — Reload returns `(nil, err)` and nothing changes at all. Wire it to any trigger: SIGHUP, an admin HTTP endpoint, fsnotify, a timer.
 
-```go
-import (
-    "log"
-    "sync/atomic"
-
-    "github.com/GiGurra/boa/pkg/boa"
-    "github.com/spf13/cobra"
-)
-
-type Params struct {
-    ConfigFile string `configfile:"true" optional:"true"`
-    Host       string `optional:"true"`
-    Port       int    `optional:"true" default:"8080"`
-}
-
-var active atomic.Pointer[Params]
-
-func main() {
-    boa.CmdT[Params]{
-        Use: "server",
-        RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
-            active.Store(p)
-
-            // Wire any trigger — SIGHUP, admin HTTP endpoint, fsnotify,
-            // a timer. On fire:
-            onReloadTrigger(func() {
-                fresh, err := boa.Reload[Params](ctx)
-                if err != nil {
-                    log.Printf("config reload rejected: %v", err) // old state preserved
-                    return
-                }
-                active.Store(fresh)
-            })
-
-            startServer()
-        },
-    }.Run()
-}
-```
-
-### What Reload does
-
-1. Allocates a fresh `*T` — the struct you were handed in `RunFunc` is **not mutated**. Callers decide what to do with the new snapshot: atomic pointer swap, diff for "did the field I care about actually change?", notify subscribers, or discard entirely. BOA doesn't dictate a concurrency model.
-2. Re-runs the full pipeline: defaults → env (re-read from the current process environment) → config files (re-read from disk) → CLI precedence (the original startup args still win) → validation → PreValidate hooks.
-3. Skips `PreExecuteFunc` and the command's `RunFunc` — a reload is value-sourcing, not command execution.
-
-### Error handling: reload is transactional
-
-Any failure during the reload — parse error from a partially-written config file, validation failure, missing file, a custom `PreValidateFunc` returning an error — causes `Reload` to return `(nil, err)`. The fresh struct is discarded and **the old struct you're holding is untouched**. Specifically:
-
-- **File parse error** (malformed JSON/YAML/TOML, truncated mid-write): the error names the offending file so operators can see what went wrong, and your atomic swap target keeps pointing at the last-known-good config.
-- **Validation failure** (`min`/`max`/`pattern`/custom validator): the error describes which field failed, old state preserved.
-- **File disappeared**: clean read error naming the path, old state preserved.
-- **PreValidate hook error**: propagated as-is, old state preserved.
-
-No "half-applied" reload is possible. This is deliberate so you can wire `Reload` to a noisy trigger (fsnotify fires 2–5 times per save on most editors) and safely ignore the errors — each failed attempt just logs and keeps serving the existing config.
-
-### What Reload does NOT do
-
-- **No fsnotify, no SIGHUP handler, no HTTP endpoint.** Wire whatever trigger makes sense for your app. The primitive just answers "give me a fresh validated config now". A higher-level watcher subpackage is planned; until then, `signal.Notify(SIGHUP)`, a timer, or a tiny admin endpoint are all ~5 lines.
-- **No concurrency coordination.** If your goroutines read from a shared `*Params`, you have to coordinate reads against whatever swap model you pick (`atomic.Pointer[T]` is the cleanest). BOA refuses to dictate sync for you.
-- **No deep merging**, no partial reload of a single file from a chain — the whole pipeline re-runs against the whole input set. Simplest semantics, easiest to reason about.
-
-### Which files get watched?
-
-`ctx.WatchedConfigFiles()` returns the paths a live-reload watcher should listen on. Auto-tracked:
-
-- Every `configfile:"true"` tagged field (single path or `[]string` overlay chain)
-- `Cmd.ConfigFormat` / `Cmd.ConfigUnmarshal` per-command escape hatches
-
-Not auto-tracked:
-
-- `boa.LoadConfigFile` / `LoadConfigFiles` / `LoadConfigBytes` called from inside a user hook — these are public helpers outside BOA's internal pipeline. Register those explicitly with `ctx.WatchConfigFile(path)` inside the same hook. The registration persists across reloads because the hook re-runs during the replay.
-
-```go
-PreValidateFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) error {
-    if err := boa.LoadConfigFile("/etc/myapp/overrides.json", p, nil); err != nil {
-        return err
-    }
-    ctx.WatchConfigFile("/etc/myapp/overrides.json") // opt in to watching
-    return nil
-},
-```
-
-### Hook behavior on reload
-
-Re-run on reload: `InitFunc`, `PostCreateFunc`, `PreValidateFunc`, and their `Ctx` variants, plus any `CfgStructInit` / `CfgStructPreValidate` interface methods on the params struct. Skipped: `PreExecuteFunc` (no action to execute) and the command's `RunFunc`. If you have state-heavy init you don't want re-run on reload, guard with a sync.Once or an "already initialized" sentinel.
+See the dedicated [Live Config Reload](live-reload.md) page for the full guide.
 
 ## Checking Value Sources
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -392,6 +392,98 @@ boa.RegisterConfigMarshaler(".yaml", yaml.Marshal)
 
 JSON comes with both directions pre-registered (pretty-printed, 2-space indent, trailing newline). See [examples-config.md](examples-config.md#writing-config-back-out) for full examples.
 
+## Live Config Reload
+
+Long-running programs (servers, daemons, background workers) often want to re-read config without restarting. BOA ships a primitive for this: `boa.Reload[T](ctx) (*T, error)`. It re-runs the entire post-flag-parse pipeline — CLI → env → config files → defaults → validation — on a **freshly allocated** `*T` and returns it.
+
+```go
+import (
+    "log"
+    "sync/atomic"
+
+    "github.com/GiGurra/boa/pkg/boa"
+    "github.com/spf13/cobra"
+)
+
+type Params struct {
+    ConfigFile string `configfile:"true" optional:"true"`
+    Host       string `optional:"true"`
+    Port       int    `optional:"true" default:"8080"`
+}
+
+var active atomic.Pointer[Params]
+
+func main() {
+    boa.CmdT[Params]{
+        Use: "server",
+        RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+            active.Store(p)
+
+            // Wire any trigger — SIGHUP, admin HTTP endpoint, fsnotify,
+            // a timer. On fire:
+            onReloadTrigger(func() {
+                fresh, err := boa.Reload[Params](ctx)
+                if err != nil {
+                    log.Printf("config reload rejected: %v", err) // old state preserved
+                    return
+                }
+                active.Store(fresh)
+            })
+
+            startServer()
+        },
+    }.Run()
+}
+```
+
+### What Reload does
+
+1. Allocates a fresh `*T` — the struct you were handed in `RunFunc` is **not mutated**. Callers decide what to do with the new snapshot: atomic pointer swap, diff for "did the field I care about actually change?", notify subscribers, or discard entirely. BOA doesn't dictate a concurrency model.
+2. Re-runs the full pipeline: defaults → env (re-read from the current process environment) → config files (re-read from disk) → CLI precedence (the original startup args still win) → validation → PreValidate hooks.
+3. Skips `PreExecuteFunc` and the command's `RunFunc` — a reload is value-sourcing, not command execution.
+
+### Error handling: reload is transactional
+
+Any failure during the reload — parse error from a partially-written config file, validation failure, missing file, a custom `PreValidateFunc` returning an error — causes `Reload` to return `(nil, err)`. The fresh struct is discarded and **the old struct you're holding is untouched**. Specifically:
+
+- **File parse error** (malformed JSON/YAML/TOML, truncated mid-write): the error names the offending file so operators can see what went wrong, and your atomic swap target keeps pointing at the last-known-good config.
+- **Validation failure** (`min`/`max`/`pattern`/custom validator): the error describes which field failed, old state preserved.
+- **File disappeared**: clean read error naming the path, old state preserved.
+- **PreValidate hook error**: propagated as-is, old state preserved.
+
+No "half-applied" reload is possible. This is deliberate so you can wire `Reload` to a noisy trigger (fsnotify fires 2–5 times per save on most editors) and safely ignore the errors — each failed attempt just logs and keeps serving the existing config.
+
+### What Reload does NOT do
+
+- **No fsnotify, no SIGHUP handler, no HTTP endpoint.** Wire whatever trigger makes sense for your app. The primitive just answers "give me a fresh validated config now". A higher-level watcher subpackage is planned; until then, `signal.Notify(SIGHUP)`, a timer, or a tiny admin endpoint are all ~5 lines.
+- **No concurrency coordination.** If your goroutines read from a shared `*Params`, you have to coordinate reads against whatever swap model you pick (`atomic.Pointer[T]` is the cleanest). BOA refuses to dictate sync for you.
+- **No deep merging**, no partial reload of a single file from a chain — the whole pipeline re-runs against the whole input set. Simplest semantics, easiest to reason about.
+
+### Which files get watched?
+
+`ctx.WatchedConfigFiles()` returns the paths a live-reload watcher should listen on. Auto-tracked:
+
+- Every `configfile:"true"` tagged field (single path or `[]string` overlay chain)
+- `Cmd.ConfigFormat` / `Cmd.ConfigUnmarshal` per-command escape hatches
+
+Not auto-tracked:
+
+- `boa.LoadConfigFile` / `LoadConfigFiles` / `LoadConfigBytes` called from inside a user hook — these are public helpers outside BOA's internal pipeline. Register those explicitly with `ctx.WatchConfigFile(path)` inside the same hook. The registration persists across reloads because the hook re-runs during the replay.
+
+```go
+PreValidateFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) error {
+    if err := boa.LoadConfigFile("/etc/myapp/overrides.json", p, nil); err != nil {
+        return err
+    }
+    ctx.WatchConfigFile("/etc/myapp/overrides.json") // opt in to watching
+    return nil
+},
+```
+
+### Hook behavior on reload
+
+Re-run on reload: `InitFunc`, `PostCreateFunc`, `PreValidateFunc`, and their `Ctx` variants, plus any `CfgStructInit` / `CfgStructPreValidate` interface methods on the params struct. Skipped: `PreExecuteFunc` (no action to execute) and the command's `RunFunc`. If you have state-heavy init you don't want re-run on reload, guard with a sync.Once or an "already initialized" sentinel.
+
 ## Checking Value Sources
 
 Use `HookContext` in your run function to check how values were set:

--- a/docs/live-reload.md
+++ b/docs/live-reload.md
@@ -1,0 +1,233 @@
+# Live Config Reload
+
+Long-running programs — servers, daemons, background workers — often want to re-read config without restarting. BOA ships a primitive for this: `boa.Reload[T](ctx) (*T, error)`. It re-runs the entire post-flag-parse pipeline — CLI → env → config files → defaults → validation — on a **freshly allocated** `*T` and returns it.
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "log"
+    "os"
+    "os/signal"
+    "sync/atomic"
+    "syscall"
+
+    "github.com/GiGurra/boa/pkg/boa"
+    "github.com/spf13/cobra"
+)
+
+type Params struct {
+    ConfigFile string `configfile:"true" optional:"true"`
+    Host       string `optional:"true"`
+    Port       int    `optional:"true" default:"8080"`
+}
+
+var active atomic.Pointer[Params]
+
+func main() {
+    boa.CmdT[Params]{
+        Use: "server",
+        RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+            active.Store(p)
+
+            // Wire a trigger — here, SIGHUP.
+            sighup := make(chan os.Signal, 1)
+            signal.Notify(sighup, syscall.SIGHUP)
+            go func() {
+                for range sighup {
+                    fresh, err := boa.Reload[Params](ctx)
+                    if err != nil {
+                        log.Printf("config reload rejected: %v", err) // old state preserved
+                        continue
+                    }
+                    active.Store(fresh)
+                    log.Println("config reloaded")
+                }
+            }()
+
+            startServer()
+        },
+    }.Run()
+}
+```
+
+`kill -HUP <pid>` now re-reads every file BOA loaded at startup, re-applies precedence (CLI still wins), re-validates, and hands you a fresh `*Params` to atomically swap. A reader goroutine that does `cfg := active.Load()` always sees a consistent snapshot.
+
+## What Reload does
+
+1. **Allocates a fresh `*T`.** The struct you were handed in `RunFunc` is **not mutated**. Callers decide what to do with the new snapshot: atomic pointer swap, diff for "did the field I care about actually change?", notify subscribers, or discard entirely. BOA doesn't dictate a concurrency model.
+2. **Re-runs the full pipeline.** Defaults → env (re-read from the current process environment) → config files (re-read from disk) → CLI precedence (the original startup args still win) → validation → `PreValidate` hooks.
+3. **Skips `PreExecuteFunc` and the command's `RunFunc`** — a reload is value-sourcing, not command execution.
+
+## Error Handling: Reload is All-or-Nothing
+
+`Reload` never mutates anything — every call is either a clean success (fresh `*T` returned) or a clean failure (`(nil, err)` returned and nothing else happens). The struct you're holding is a completely separate allocation that Reload can't see; your atomic swap target keeps pointing at whatever it was pointing at before.
+
+| Failure | What the caller sees |
+|---|---|
+| **File parse error** (malformed JSON/YAML/TOML, truncated mid-write) | Error names the offending file. Nothing allocated, nothing swapped — the previous snapshot is still the live one. |
+| **Validation failure** (`min` / `max` / `pattern` / custom validator) | Error describes which field failed. Fresh struct is discarded before it ever leaves Reload. |
+| **File disappeared** | Clean read error naming the path. |
+| **PreValidate hook error** | Propagated as-is. |
+
+This is deliberate so you can wire `Reload` to a noisy trigger — fsnotify fires 2–5 times per save on most editors — and safely ignore every error. Each failed attempt just logs and keeps serving the existing config:
+
+```go
+for range fileChanges {
+    fresh, err := boa.Reload[Params](ctx)
+    if err != nil {
+        log.Printf("reload failed (keeping current config): %v", err)
+        continue
+    }
+    active.Store(fresh)
+}
+```
+
+## What Reload does NOT do
+
+- **No fsnotify, no SIGHUP handler, no HTTP endpoint.** The primitive just answers "give me a fresh validated config now". Wire whatever trigger makes sense — `signal.Notify(syscall.SIGHUP)`, a timer, a tiny admin endpoint, fsnotify, a test harness. A higher-level watcher subpackage that wraps fsnotify with sane debouncing is planned as a follow-up.
+- **No concurrency coordination.** If your goroutines read from a shared `*Params`, you have to coordinate reads against whatever swap model you pick. `atomic.Pointer[T]` is the cleanest, but `sync.RWMutex` works too. BOA refuses to dictate sync for you.
+- **No deep merging**, no partial reload of a single file from a chain — the whole pipeline re-runs against the whole input set. Simplest semantics, easiest to reason about.
+
+## Which Files Get Watched?
+
+`ctx.WatchedConfigFiles()` returns the paths a live-reload watcher should listen on. Use this to hand the file set to fsnotify / your custom watcher of choice.
+
+### Auto-tracked
+
+- Every `configfile:"true"` tagged field (single path or `[]string` overlay chain)
+- `Cmd.ConfigFormat` / `Cmd.ConfigUnmarshal` per-command escape hatches
+
+### Not auto-tracked
+
+`boa.LoadConfigFile` / `LoadConfigFiles` / `LoadConfigBytes` called from inside a user hook — these are public helpers outside BOA's internal pipeline. Register those explicitly with `ctx.WatchConfigFile(path)` inside the same hook. The registration persists across reloads because the hook re-runs during the replay:
+
+```go
+PreValidateFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) error {
+    if err := boa.LoadConfigFile("/etc/myapp/overrides.json", p, nil); err != nil {
+        return err
+    }
+    ctx.WatchConfigFile("/etc/myapp/overrides.json") // opt in to watching
+    return nil
+},
+```
+
+## Hook Behavior on Reload
+
+| Hook | Runs on reload? |
+|---|---|
+| `InitFunc` / `InitFuncCtx` | ✅ |
+| `PostCreateFunc` / `PostCreateFuncCtx` | ✅ |
+| `PreValidateFunc` / `PreValidateFuncCtx` | ✅ |
+| `PreExecuteFunc` / `PreExecuteFuncCtx` | ❌ (no main action to run) |
+| `RunFunc` / `RunFuncCtx` / `RunFuncE` / `RunFuncCtxE` | ❌ (no main action to run) |
+| `CfgStructInit` / `CfgStructPreValidate` interface methods | ✅ |
+| `CfgStructPreExecute` interface methods | ❌ |
+
+If you have state-heavy init you don't want re-run on reload, guard with a `sync.Once` or an "already initialized" sentinel inside the hook.
+
+## Typical Triggers
+
+### SIGHUP (POSIX convention)
+
+```go
+sighup := make(chan os.Signal, 1)
+signal.Notify(sighup, syscall.SIGHUP)
+go func() {
+    for range sighup {
+        if fresh, err := boa.Reload[Params](ctx); err == nil {
+            active.Store(fresh)
+        }
+    }
+}()
+```
+
+### Admin HTTP endpoint
+
+```go
+http.HandleFunc("/admin/reload", func(w http.ResponseWriter, r *http.Request) {
+    fresh, err := boa.Reload[Params](ctx)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+    active.Store(fresh)
+    w.WriteHeader(http.StatusNoContent)
+})
+```
+
+### fsnotify (watch the directory, not the file, to survive atomic-rename-saves)
+
+```go
+watcher, _ := fsnotify.NewWatcher()
+defer watcher.Close()
+watched := ctx.WatchedConfigFiles()
+dirs := map[string]bool{}
+for _, p := range watched {
+    dirs[filepath.Dir(p)] = true
+}
+for d := range dirs {
+    watcher.Add(d)
+}
+targets := map[string]bool{}
+for _, p := range watched {
+    targets[p] = true
+}
+debounce := time.NewTimer(time.Hour)
+debounce.Stop()
+for {
+    select {
+    case ev := <-watcher.Events:
+        if targets[ev.Name] {
+            debounce.Reset(200 * time.Millisecond)
+        }
+    case <-debounce.C:
+        if fresh, err := boa.Reload[Params](ctx); err == nil {
+            active.Store(fresh)
+        }
+    }
+}
+```
+
+### Timer (poll every N seconds)
+
+```go
+ticker := time.NewTicker(30 * time.Second)
+defer ticker.Stop()
+for range ticker.C {
+    if fresh, err := boa.Reload[Params](ctx); err == nil {
+        active.Store(fresh)
+    }
+}
+```
+
+## Reading the Active Config from Worker Goroutines
+
+The atomic-pointer pattern keeps readers lock-free and always-consistent:
+
+```go
+var active atomic.Pointer[Params]
+
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    cfg := active.Load() // always points at a fully-validated, immutable snapshot
+    fmt.Fprintf(w, "host=%s port=%d\n", cfg.Host, cfg.Port)
+}
+```
+
+Each `active.Load()` returns the pointer that was current when the load began. A concurrent `Store` from the reload goroutine can swap it — in-flight readers continue with the old snapshot, new readers see the new one. No torn reads, no locks.
+
+If you need to react to specific changes — "port changed, restart the listener" — diff the old and new snapshots after the swap:
+
+```go
+old := active.Load()
+fresh, err := boa.Reload[Params](ctx)
+if err != nil {
+    return
+}
+active.Store(fresh)
+if fresh.Port != old.Port {
+    go restartListener(fresh.Port)
+}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - Config File Examples: examples-config.md
     - Advanced Examples: examples-advanced.md
   - Advanced: advanced.md
+  - Live Config Reload: live-reload.md
   - Global Config: global-config.md
   - Cobra Interoperability: cobra-interop.md
   - Migration Guide: migration.md

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -92,6 +92,19 @@ type Cmd struct {
 	ConfigFormat ConfigFormat
 	// RawArgs allows injecting command line arguments instead of using os.Args
 	RawArgs []string
+
+	// reloadFactory, when non-nil, allocates a fresh copy of the params
+	// struct and re-runs the full post-flag-parse pipeline (defaults →
+	// env → config files → CLI precedence → validation → pre-validate
+	// hooks) against it, returning the validated fresh struct. It is
+	// populated by CmdT[T].ToCmd so that the generic type parameter is
+	// captured *before* the generic→non-generic bridge, letting
+	// HookContext.Reload / boa.Reload return typed structs.
+	//
+	// Unexported so users can't accidentally wire it themselves — reload
+	// only makes sense when it goes through the same pipeline the command
+	// was built with.
+	reloadFactory func() (any, error)
 }
 
 // HasValue checks if a parameter has a value from any source.
@@ -480,6 +493,128 @@ func (c *HookContext) HasValue(fieldPtr any) bool {
 		return false
 	}
 	return HasValue(param)
+}
+
+// WatchedConfigFiles returns every config file path the pipeline read
+// during the most recent run, plus any paths explicitly registered via
+// WatchConfigFile. This is the input a live-reload watcher needs: the set
+// of filesystem paths whose changes should trigger a Reload.
+//
+// Auto-tracked sources:
+//
+//   - `configfile:"true"` tagged fields (single path or []string overlay chain)
+//   - Per-command `Cmd.ConfigFormat` / `Cmd.ConfigUnmarshal` escape hatches
+//     (they go through the same internal loader)
+//
+// Not auto-tracked:
+//
+//   - Files loaded via boa.LoadConfigFile / boa.LoadConfigFiles /
+//     boa.LoadConfigBytes called from inside user hooks. Those are public
+//     helpers outside boa's internal pipeline, so boa doesn't see them.
+//     Call ctx.WatchConfigFile(path) inside the same hook to opt those
+//     in — the registry is reset at the top of every pipeline run, so a
+//     reload that re-runs the hook re-registers cleanly.
+//
+// Order is stable: tagged / escape-hatch loads first (in the order they
+// fired), followed by explicit WatchConfigFile registrations in call
+// order. Duplicate paths are preserved as-is — dedup at the watcher
+// level if it matters to you.
+func (c *HookContext) WatchedConfigFiles() []string {
+	if c == nil || c.ctx == nil {
+		return nil
+	}
+	total := len(c.ctx.LoadedConfigFiles) + len(c.ctx.ExtraWatchedConfigFiles)
+	if total == 0 {
+		return nil
+	}
+	out := make([]string, 0, total)
+	out = append(out, c.ctx.LoadedConfigFiles...)
+	out = append(out, c.ctx.ExtraWatchedConfigFiles...)
+	return out
+}
+
+// WatchConfigFile registers an extra config file path so a live-reload
+// watcher covers it even though boa's internal pipeline didn't load it.
+// The typical caller is a PreValidateFunc that called LoadConfigFile /
+// LoadConfigFiles / LoadConfigBytes manually and wants those paths
+// watched alongside the auto-tracked tagged fields.
+//
+// Empty paths are silently ignored so callers don't need a length check
+// around optional overrides. The registry is reset at the top of every
+// pipeline run (including reloads), so hooks that re-run will
+// re-register cleanly without duplicating.
+func (c *HookContext) WatchConfigFile(path string) {
+	if c == nil || c.ctx == nil || path == "" {
+		return
+	}
+	c.ctx.ExtraWatchedConfigFiles = append(c.ctx.ExtraWatchedConfigFiles, path)
+}
+
+// reloadAny re-runs the full post-flag-parse pipeline on a freshly
+// allocated params struct, using the original CLI arguments captured at
+// startup. On success it returns the fresh struct; on validation or load
+// failure the old struct held by the caller is untouched.
+//
+// This is the non-generic core of the reload primitive. Users should
+// call the generic boa.Reload[T] wrapper, which type-asserts the result
+// back to *T so they never see the any.
+func (c *HookContext) reloadAny() (any, error) {
+	if c == nil || c.ctx == nil {
+		return nil, fmt.Errorf("boa: HookContext.Reload: uninitialized HookContext")
+	}
+	if c.ctx.reloadFactory == nil {
+		return nil, fmt.Errorf("boa: HookContext.Reload: no reload factory registered — this HookContext came from a Cmd that was constructed without CmdT[T].ToCmd (the generic wrapper is what installs the factory)")
+	}
+	return c.ctx.reloadFactory()
+}
+
+// Reload re-runs the full post-flag-parse pipeline on a freshly
+// allocated *T and returns the new struct. CLI values from the original
+// invocation still win over env / config / defaults, environment
+// variables are re-read, and every auto-tracked config file is re-read
+// from disk. Validation runs against the new struct; on failure the old
+// struct the caller is holding is untouched and the error is returned.
+//
+// Reload does NOT mutate the params struct that RunFunc / RunFuncCtx was
+// originally called with. Callers get a fresh *T and decide what to do
+// with it: atomic pointer swap, diff-and-notify, copy specific fields,
+// discard. Boa does not dictate a concurrency model — you pick.
+//
+// Hooks that run on reload: InitFunc, PostCreateFunc, PreValidateFunc,
+// and their Ctx variants, plus any CfgStructInit / CfgStructPreValidate
+// interface methods implemented on params. Hooks that DO NOT run on
+// reload: PreExecuteFunc (and Ctx) and the command's own RunFunc — a
+// reload is value-sourcing + validation, not command execution.
+//
+// Typical use:
+//
+//	boa.CmdT[Params]{
+//	    RunFuncCtx: func(ctx *boa.HookContext, p *Params, cmd *cobra.Command, args []string) {
+//	        // Wire some trigger — SIGHUP, an admin HTTP endpoint,
+//	        // fsnotify, a timer. On fire:
+//	        newP, err := boa.Reload[Params](ctx)
+//	        if err != nil {
+//	            log.Printf("config reload rejected: %v", err)
+//	            return // old state preserved
+//	        }
+//	        // atomic swap, diff, notify subscribers, etc.
+//	        cfg.Store(newP)
+//	    },
+//	}.Run()
+//
+// Reload is safe to call from any goroutine, but it's the caller's
+// responsibility to coordinate readers against whatever swap model they
+// choose (atomic.Pointer, RWMutex, etc.).
+func Reload[T any](ctx *HookContext) (*T, error) {
+	raw, err := ctx.reloadAny()
+	if err != nil {
+		return nil, err
+	}
+	typed, ok := raw.(*T)
+	if !ok {
+		return nil, fmt.Errorf("boa.Reload: reloaded params is %T, not *%T — check that the type parameter matches CmdT[T]", raw, *new(T))
+	}
+	return typed, nil
 }
 
 // DumpBytes serializes the parameters associated with this HookContext to

--- a/pkg/boa/api_typed_base.go
+++ b/pkg/boa/api_typed_base.go
@@ -203,6 +203,43 @@ func (b CmdT[Struct]) ToCmd() Cmd {
 		params = b.Params
 	}
 
+	// reloadFactory is built at the typed layer so the generic Struct
+	// parameter is captured in the closure. When invoked, it allocates a
+	// fresh *Struct, constructs a copy of b with the new params and every
+	// run/execute hook replaced by no-ops, and re-runs the full pipeline
+	// through the standard CmdT[Struct].RunArgsE entry point. The no-op
+	// RunFunc is important: cobra skips PreRunE (and therefore all of
+	// boa's value-sourcing + validation) when the command has nothing to
+	// run. We want the pipeline to fire but we don't want the user's real
+	// action, so we substitute the quietest possible runner.
+	reloadFactory := func() (any, error) {
+		bCopy := b
+		fresh := new(Struct)
+		bCopy.Params = fresh
+
+		// Replace every run hook with a no-op. Only one run hook may be
+		// set at a time (boa enforces this), so clearing the others and
+		// installing exactly one no-op keeps validation happy. We use
+		// RunFunc as the designated slot.
+		bCopy.RunFunc = func(*Struct, *cobra.Command, []string) {}
+		bCopy.RunFuncCtx = nil
+		bCopy.RunFuncE = nil
+		bCopy.RunFuncCtxE = nil
+
+		// Pre-execute hooks represent "right before the main action" —
+		// there's no main action on a reload, so drop them. Init, Post-
+		// Create, and PreValidate all re-run because they're part of
+		// value-sourcing / derivation and often load additional state.
+		bCopy.PreExecuteFunc = nil
+		bCopy.PreExecuteFuncCtx = nil
+
+		bCopy.RawArgs = b.RawArgs
+		if err := bCopy.RunArgsE(b.RawArgs); err != nil {
+			return nil, err
+		}
+		return fresh, nil
+	}
+
 	return Cmd{
 		Use:                b.Use,
 		Short:              b.Short,
@@ -234,6 +271,7 @@ func (b CmdT[Struct]) ToCmd() Cmd {
 		ConfigUnmarshal:    b.ConfigUnmarshal,
 		ConfigFormat:       b.ConfigFormat,
 		RawArgs:            b.RawArgs,
+		reloadFactory:      reloadFactory,
 	}
 }
 

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -343,6 +343,34 @@ type processingContext struct {
 	// mentioned in a config file (even if no child fields were set, e.g., "DB": {}).
 	// These survive cleanup regardless of whether individual fields were set.
 	ConfigPresentPtrs map[uintptr]bool
+
+	// LoadedConfigFiles records every config file path the pipeline actually
+	// read during this run — both from configfile:"true" tagged fields and
+	// from Cmd.ConfigFormat / ConfigUnmarshal escape hatches. Populated
+	// inside the PreRunE wrapper as files are loaded; cleared at the start
+	// of every reload. Exposed to users via HookContext.WatchedConfigFiles
+	// so the live-reload watcher knows which paths to listen on.
+	//
+	// Files loaded via the public helpers LoadConfigFile / LoadConfigFiles
+	// called from inside a user hook are NOT auto-tracked — those are
+	// outside boa's internal pipeline. Users who load files manually can
+	// register them explicitly via HookContext.WatchConfigFile so they
+	// show up in the watched list too.
+	LoadedConfigFiles []string
+
+	// ExtraWatchedConfigFiles holds paths that users registered via
+	// HookContext.WatchConfigFile — typically config files they loaded
+	// themselves inside a PreValidateFunc via boa.LoadConfigFile /
+	// boa.LoadConfigFiles. These are surfaced alongside LoadedConfigFiles
+	// in HookContext.WatchedConfigFiles so the live-reload watcher covers
+	// them too.
+	ExtraWatchedConfigFiles []string
+
+	// reloadFactory mirrors Cmd.reloadFactory for in-pipeline access. It
+	// is populated from b.reloadFactory at the top of toCobraBaseImpl so
+	// HookContext.reloadAny / boa.Reload can invoke it without knowing
+	// about the outer Cmd.
+	reloadFactory func() (any, error)
 }
 
 // preallocateStructPtrs walks the struct tree and allocates any nil struct pointer fields,
@@ -1747,6 +1775,7 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 		mirrorByPath:  map[fieldPath]Param{},
 		pathOrder:     []fieldPath{},
 		addrToPath:    map[unsafe.Pointer]fieldPath{},
+		reloadFactory: b.reloadFactory,
 	}
 
 	// Preallocate nil struct pointer fields so traverse can discover their children.
@@ -2165,6 +2194,12 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if b.Params != nil {
 
+			// Reset the live-reload path registries at the top of every
+			// pipeline run so a reload sees a fresh list that reflects
+			// only what this run actually loaded.
+			ctx.LoadedConfigFiles = ctx.LoadedConfigFiles[:0]
+			ctx.ExtraWatchedConfigFiles = ctx.ExtraWatchedConfigFiles[:0]
+
 			// Must read env values before running any prevalidate code
 			if err := parseEnv(ctx, b.Params); err != nil {
 				return err
@@ -2243,6 +2278,11 @@ func (b Cmd) toCobraBase() (*cobra.Command, *processingContext, error) {
 							format:     effective,
 							ext:        filepath.Ext(filePath),
 						})
+						// Record the path so HookContext.WatchedConfigFiles
+						// can hand it to a live-reload watcher. Reset at
+						// the top of PreRunE above so a reload sees a
+						// fresh list.
+						ctx.LoadedConfigFiles = append(ctx.LoadedConfigFiles, filePath)
 					}
 					return nil
 				}

--- a/pkg/boa/reload_test.go
+++ b/pkg/boa/reload_test.go
@@ -1,0 +1,556 @@
+package boa
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// reloadTestParams covers the main bits we care about on reload: plain
+// scalars, a field with a default, a field only ever set via config, and a
+// configfile path.
+type reloadTestParams struct {
+	ConfigFile string `configfile:"true" optional:"true"`
+	Host       string `optional:"true"`
+	Port       int    `optional:"true" default:"8080"`
+	Region     string `optional:"true"`
+}
+
+func writeReloadFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+// --- Core reload semantics ---
+
+func TestReload_PicksUpConfigFileEdits(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"initial","Region":"us"}`)
+
+	var (
+		firstHost   string
+		firstRegion string
+		secondHost  string
+		secondRegion string
+	)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			firstHost = p.Host
+			firstRegion = p.Region
+
+			// Edit the file on disk and reload.
+			if err := os.WriteFile(cfgPath, []byte(`{"Host":"updated","Region":"eu"}`), 0644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			fresh, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			secondHost = fresh.Host
+			secondRegion = fresh.Region
+
+			// Original struct must be unchanged — reload returns a fresh allocation.
+			if p.Host != "initial" {
+				t.Errorf("old struct mutated: Host=%q want 'initial'", p.Host)
+			}
+			if p.Region != "us" {
+				t.Errorf("old struct mutated: Region=%q want 'us'", p.Region)
+			}
+			// Fresh struct pointer must differ from the original.
+			if fresh == p {
+				t.Error("expected fresh allocation, got same pointer as original params")
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+
+	if firstHost != "initial" || firstRegion != "us" {
+		t.Errorf("first read unexpected: host=%q region=%q", firstHost, firstRegion)
+	}
+	if secondHost != "updated" || secondRegion != "eu" {
+		t.Errorf("reload failed to pick up edits: host=%q region=%q", secondHost, secondRegion)
+	}
+}
+
+func TestReload_CLIStillWinsAfterReload(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"from-file","Region":"us"}`)
+
+	var (
+		firstHost  string
+		secondHost string
+	)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			firstHost = p.Host // "from-cli" should win at startup
+
+			// File change shouldn't affect Host — CLI still wins on reload.
+			if err := os.WriteFile(cfgPath, []byte(`{"Host":"changed-in-file","Region":"eu"}`), 0644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			fresh, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			secondHost = fresh.Host
+			if fresh.Region != "eu" {
+				t.Errorf("expected Region=eu from reloaded file, got %q", fresh.Region)
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath, "--host", "from-cli"})
+
+	if firstHost != "from-cli" {
+		t.Errorf("first read: expected CLI host, got %q", firstHost)
+	}
+	if secondHost != "from-cli" {
+		t.Errorf("reload must preserve CLI Host: got %q want 'from-cli'", secondHost)
+	}
+}
+
+func TestReload_DefaultsArePinned(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"h"}`)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			if p.Port != 8080 {
+				t.Errorf("startup Port: got %d want 8080 (default)", p.Port)
+			}
+			fresh, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			if fresh.Port != 8080 {
+				t.Errorf("reload Port: got %d want 8080 (default re-applied)", fresh.Port)
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+}
+
+// --- Validation failure semantics ---
+
+func TestReload_ValidationFailureLeavesOldStateIntact(t *testing.T) {
+	type StrictParams struct {
+		ConfigFile string `configfile:"true" optional:"true"`
+		Port       int    `optional:"true" min:"1" max:"65535"`
+	}
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Port":3000}`)
+
+	CmdT[StrictParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *StrictParams, cmd *cobra.Command, args []string) {
+			if p.Port != 3000 {
+				t.Errorf("startup: expected Port=3000, got %d", p.Port)
+			}
+
+			// Rewrite the file with an out-of-range port.
+			if err := os.WriteFile(cfgPath, []byte(`{"Port":70000}`), 0644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			fresh, err := Reload[StrictParams](ctx)
+			if err == nil {
+				t.Fatalf("expected validation error on reload, got fresh=%+v", fresh)
+			}
+			if fresh != nil {
+				t.Errorf("expected nil fresh params on error, got %+v", fresh)
+			}
+			// Old state must be untouched.
+			if p.Port != 3000 {
+				t.Errorf("old struct mutated after failed reload: Port=%d want 3000", p.Port)
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+}
+
+func TestReload_MalformedFileReturnsErrorAndPreservesOldState(t *testing.T) {
+	// A partially-written file (e.g. the editor/deploy process caught
+	// mid-write) must produce a parse error, NOT a silent fallback to
+	// defaults. The caller's existing struct stays intact.
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"good","Region":"us"}`)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			if p.Host != "good" {
+				t.Fatalf("startup: Host=%q want 'good'", p.Host)
+			}
+
+			// Corrupt the file — truncated JSON mid-key.
+			if err := os.WriteFile(cfgPath, []byte(`{"Host":"partial`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			fresh, err := Reload[reloadTestParams](ctx)
+			if err == nil {
+				t.Fatalf("expected parse error on malformed JSON, got fresh=%+v", fresh)
+			}
+			if fresh != nil {
+				t.Errorf("expected nil fresh on parse error, got %+v", fresh)
+			}
+			// Error should name the file so the operator can see what went wrong.
+			if !strings.Contains(err.Error(), cfgPath) {
+				t.Errorf("expected error to name the bad file, got: %v", err)
+			}
+			// Old state must be untouched — reload is transactional.
+			if p.Host != "good" || p.Region != "us" {
+				t.Errorf("old struct mutated after failed reload: %+v", *p)
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+}
+
+func TestReload_MissingFileDuringReloadReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"h"}`)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			if err := os.Remove(cfgPath); err != nil {
+				t.Fatalf("rm: %v", err)
+			}
+			_, err := Reload[reloadTestParams](ctx)
+			if err == nil {
+				t.Fatal("expected error when reload target no longer exists")
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+}
+
+// --- Multi-file overlay reload ---
+
+func TestReload_MultiFileOverlay(t *testing.T) {
+	type Params struct {
+		ConfigFiles []string `configfile:"true" optional:"true"`
+		Host        string   `optional:"true"`
+		Port        int      `optional:"true"`
+		Region      string   `optional:"true"`
+	}
+
+	dir := t.TempDir()
+	base := writeReloadFile(t, dir, "base.json", `{"Host":"base","Port":80,"Region":"us"}`)
+	local := writeReloadFile(t, dir, "local.json", `{"Port":8080}`)
+
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			if p.Host != "base" || p.Port != 8080 || p.Region != "us" {
+				t.Errorf("startup: got %+v", *p)
+			}
+
+			// Rewrite both files. local now changes Region too; base changes Host.
+			if err := os.WriteFile(base, []byte(`{"Host":"base2","Port":70,"Region":"us2"}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(local, []byte(`{"Port":9090,"Region":"eu"}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			fresh, err := Reload[Params](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			if fresh.Host != "base2" {
+				t.Errorf("reload Host: got %q want 'base2' (only base sets it)", fresh.Host)
+			}
+			if fresh.Port != 9090 {
+				t.Errorf("reload Port: got %d want 9090 (local wins)", fresh.Port)
+			}
+			if fresh.Region != "eu" {
+				t.Errorf("reload Region: got %q want 'eu' (local wins)", fresh.Region)
+			}
+		},
+	}.RunArgs([]string{"--config-files", base + "," + local})
+}
+
+// --- WatchedConfigFiles + WatchConfigFile registration ---
+
+func TestWatchedConfigFiles_AutoTracksConfigfileTag(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"h"}`)
+
+	var watched []string
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			watched = ctx.WatchedConfigFiles()
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+
+	if len(watched) != 1 || watched[0] != cfgPath {
+		t.Errorf("expected WatchedConfigFiles=[%q], got %v", cfgPath, watched)
+	}
+}
+
+func TestWatchedConfigFiles_IncludesMultiFileChain(t *testing.T) {
+	type Params struct {
+		ConfigFiles []string `configfile:"true" optional:"true"`
+		Host        string   `optional:"true"`
+	}
+	dir := t.TempDir()
+	base := writeReloadFile(t, dir, "base.json", `{"Host":"a"}`)
+	local := writeReloadFile(t, dir, "local.json", `{"Host":"b"}`)
+
+	var watched []string
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			watched = ctx.WatchedConfigFiles()
+		},
+	}.RunArgs([]string{"--config-files", base + "," + local})
+
+	if len(watched) != 2 {
+		t.Fatalf("expected 2 watched files, got %v", watched)
+	}
+	if watched[0] != base || watched[1] != local {
+		t.Errorf("expected [%q, %q], got %v", base, local, watched)
+	}
+}
+
+func TestWatchedConfigFiles_ExtraRegistrationFromHook(t *testing.T) {
+	type Params struct {
+		Host string `optional:"true"`
+	}
+	dir := t.TempDir()
+	extra := writeReloadFile(t, dir, "extra.json", `{"Host":"from-hook"}`)
+
+	var watched []string
+	CmdT[Params]{
+		Use: "test",
+		PreValidateFunc: func(p *Params, cmd *cobra.Command, args []string) error {
+			return LoadConfigFile(extra, p, nil)
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			// User manually wires the watch since LoadConfigFile can't auto-track.
+			ctx.WatchConfigFile(extra)
+			watched = ctx.WatchedConfigFiles()
+		},
+	}.RunArgs([]string{})
+
+	if len(watched) != 1 || watched[0] != extra {
+		t.Errorf("expected [%q], got %v", extra, watched)
+	}
+}
+
+func TestWatchedConfigFiles_EmptyRegistrationIgnored(t *testing.T) {
+	var watched []string
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			ctx.WatchConfigFile("")
+			ctx.WatchConfigFile("")
+			watched = ctx.WatchedConfigFiles()
+		},
+	}.RunArgs([]string{})
+
+	if len(watched) != 0 {
+		t.Errorf("expected empty, got %v", watched)
+	}
+}
+
+// --- Safety / concurrency contract ---
+
+func TestReload_FreshAllocationPerCall(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"a"}`)
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			first, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("first reload: %v", err)
+			}
+			second, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("second reload: %v", err)
+			}
+			if first == second {
+				t.Error("expected distinct pointers across reloads")
+			}
+			if first == p || second == p {
+				t.Error("reload must not return the original params pointer")
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+}
+
+func TestReload_AtomicSwapPattern(t *testing.T) {
+	// Demonstrates the idiomatic way to use Reload in a long-running program:
+	// keep an atomic.Pointer and swap on successful reload. Readers never
+	// see a half-updated struct.
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"a","Region":"us"}`)
+
+	var active atomic.Pointer[reloadTestParams]
+
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			active.Store(p)
+
+			if err := os.WriteFile(cfgPath, []byte(`{"Host":"b","Region":"eu"}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			fresh, err := Reload[reloadTestParams](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			active.Store(fresh)
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+
+	cur := active.Load()
+	if cur == nil {
+		t.Fatal("no active params")
+	}
+	if cur.Host != "b" || cur.Region != "eu" {
+		t.Errorf("active params after swap: got %+v", *cur)
+	}
+}
+
+// --- Error messaging ---
+
+func TestReload_ClearErrorWhenFactoryMissing(t *testing.T) {
+	// Build a HookContext without the reload factory (i.e. one constructed
+	// directly via Cmd, not CmdT[T]). This exercises the "no factory" error
+	// path so users don't get a cryptic nil-pointer panic.
+	ctx := &HookContext{ctx: &processingContext{}}
+	_, err := Reload[reloadTestParams](ctx)
+	if err == nil {
+		t.Fatal("expected error when reloadFactory is nil")
+	}
+	if !strings.Contains(err.Error(), "no reload factory") {
+		t.Errorf("expected 'no reload factory' error, got: %v", err)
+	}
+}
+
+func TestReload_SequentialReloadsSeeProgressiveEdits(t *testing.T) {
+	// Simulates a file being edited N times; each reload must see the
+	// latest state. Catches "reload reads from a stale snapshot" bugs
+	// where we might accidentally cache the first load's bytes.
+	dir := t.TempDir()
+	cfgPath := writeReloadFile(t, dir, "cfg.json", `{"Host":"v0"}`)
+
+	var seen []string
+	CmdT[reloadTestParams]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *reloadTestParams, cmd *cobra.Command, args []string) {
+			seen = append(seen, p.Host)
+			for i := 1; i <= 3; i++ {
+				if err := os.WriteFile(cfgPath, []byte(`{"Host":"v`+string(rune('0'+i))+`"}`), 0644); err != nil {
+					t.Fatal(err)
+				}
+				fresh, err := Reload[reloadTestParams](ctx)
+				if err != nil {
+					t.Fatalf("reload %d: %v", i, err)
+				}
+				seen = append(seen, fresh.Host)
+			}
+		},
+	}.RunArgs([]string{"--config-file", cfgPath})
+
+	want := []string{"v0", "v1", "v2", "v3"}
+	if len(seen) != len(want) {
+		t.Fatalf("expected %v, got %v", want, seen)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Errorf("step %d: got %q want %q", i, seen[i], want[i])
+		}
+	}
+}
+
+func TestWatchedConfigFiles_ExtraRegistrationSurvivesReload(t *testing.T) {
+	// A PreValidateFunc that manually loads a file and registers it for
+	// watching needs the registration to persist across reload — the
+	// hook re-runs during the replay, so it re-registers cleanly.
+	type Params struct {
+		Host string `optional:"true"`
+	}
+	dir := t.TempDir()
+	extra := writeReloadFile(t, dir, "extra.json", `{"Host":"v0"}`)
+
+	var (
+		firstWatched  []string
+		secondWatched []string
+	)
+	CmdT[Params]{
+		Use: "test",
+		PreValidateFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) error {
+			if err := LoadConfigFile(extra, p, nil); err != nil {
+				return err
+			}
+			ctx.WatchConfigFile(extra)
+			return nil
+		},
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			firstWatched = ctx.WatchedConfigFiles()
+
+			if err := os.WriteFile(extra, []byte(`{"Host":"v1"}`), 0644); err != nil {
+				t.Fatal(err)
+			}
+			fresh, err := Reload[Params](ctx)
+			if err != nil {
+				t.Fatalf("Reload: %v", err)
+			}
+			if fresh.Host != "v1" {
+				t.Errorf("reload didn't pick up PreValidate-loaded file edit: got %q", fresh.Host)
+			}
+			secondWatched = ctx.WatchedConfigFiles()
+		},
+	}.RunArgs([]string{})
+
+	if len(firstWatched) != 1 || firstWatched[0] != extra {
+		t.Errorf("first watched: got %v", firstWatched)
+	}
+	// The outer ctx still belongs to the original command — its registry
+	// was NOT touched by the inner reload (which ran against a fresh ctx),
+	// so it should still report the single extra path.
+	if len(secondWatched) != 1 || secondWatched[0] != extra {
+		t.Errorf("second watched: got %v", secondWatched)
+	}
+}
+
+func TestReload_TypeMismatchProducesClearError(t *testing.T) {
+	type Params struct {
+		Host string `optional:"true"`
+	}
+	type OtherParams struct {
+		Host string `optional:"true"`
+	}
+
+	var reloadErr error
+	CmdT[Params]{
+		Use: "test",
+		RunFuncCtx: func(ctx *HookContext, p *Params, cmd *cobra.Command, args []string) {
+			// Ask for the wrong type.
+			_, err := Reload[OtherParams](ctx)
+			reloadErr = err
+		},
+	}.RunArgs([]string{})
+
+	if reloadErr == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	if !errors.Is(reloadErr, reloadErr) { // sanity: non-nil
+		t.Fatal("unreachable")
+	}
+	if !strings.Contains(reloadErr.Error(), "not *") {
+		t.Errorf("expected type mismatch hint, got: %v", reloadErr)
+	}
+}


### PR DESCRIPTION
## Summary

For long-running programs (servers, daemons, workers) that want to re-read config without restarting, this adds the core reload primitive:

```go
newP, err := boa.Reload[Params](ctx)
```

`Reload` re-runs the full post-flag-parse pipeline — CLI → env → config files → defaults → validation → PreValidate hooks — on a **freshly allocated** `*T` and returns it. The struct you originally got in `RunFunc` is never mutated; callers decide what to do with the new snapshot (typically `atomic.Pointer[T].Store`, but BOA doesn't dictate a concurrency model).

## Semantics

1. **Fresh allocation per call.** The caller's existing struct is completely separate from anything Reload touches. Safe to call from any goroutine.
2. **Full pipeline re-run.** CLI precedence from the original invocation still wins over env / config / defaults. Env is re-read from the current process environment. Config files are re-read from disk.
3. **All-or-nothing.** On any failure (parse error, validation failure, missing file, PreValidate hook error) `Reload` returns `(nil, err)` and nothing else changes. Safe to wire to noisy triggers like fsnotify (which fires 2–5 events per save on most editors) — each failed attempt just logs and keeps serving the existing snapshot.
4. **Hooks on reload.** Re-runs: `InitFunc`, `PostCreateFunc`, `PreValidateFunc` and their `Ctx` variants, plus `CfgStructInit` / `CfgStructPreValidate` interface methods. Skipped: `PreExecuteFunc` and the command's `RunFunc` (a reload is value-sourcing, not command execution).

## Path tracking for watchers

`ctx.WatchedConfigFiles()` returns the paths a live-reload watcher should listen on. Auto-tracks `configfile:\"true\"` tagged fields (single path or `[]string` overlay chain) and `Cmd.ConfigFormat` / `Cmd.ConfigUnmarshal` escape hatches. For files loaded manually from a hook via `LoadConfigFile` / `LoadConfigFiles` / `LoadConfigBytes`, users opt in with `ctx.WatchConfigFile(path)` — registration persists across reloads because the hook re-runs during replay.

## No fsnotify in this PR

Wire your own trigger: SIGHUP, admin HTTP endpoint, fsnotify, a timer, a test harness. The primitive just answers \"give me a fresh validated config now\". A higher-level watcher subpackage (`pkg/boawatch`) built on top of this primitive is the planned follow-up, keeping core dep-free.

## Implementation notes

- `CmdT[T].ToCmd` installs a `reloadFactory` closure that captures the generic `Struct` type parameter, allocates a fresh `*Struct` per call, replaces every run hook with a no-op, and re-enters the pipeline via `RunArgsE`. The no-op `RunFunc` is load-bearing — cobra skips `PreRunE` (and therefore all of BOA's value-sourcing + validation) when the command has nothing to run.
- `Cmd` gains an unexported `reloadFactory` field so the generic closure survives the typed→non-generic bridge. `processingContext` copies it so `HookContext` can reach it without knowing about the outer `Cmd`.
- `processingContext` gains `LoadedConfigFiles` and `ExtraWatchedConfigFiles`; both are reset at the top of every `PreRunE` run so reloads start with a clean slate.
- `boa.Reload[T]` is a generic free function that wraps the non-generic `HookContext.reloadAny` and type-asserts the result back to `*T` with a clear error message on mismatch.

## Tests

- Config file edits picked up on reload
- CLI precedence survives reload (startup `--host=x` still wins over re-read file)
- Struct defaults re-applied on reload
- Validation failure → `(nil, err)` with old state intact
- **Malformed file** (truncated JSON mid-key, simulating partial writes) → clean parse error naming the file, old state intact
- Missing file → clean read error, old state intact
- Multi-file overlay chain re-loads correctly with precedence
- Atomic pointer swap pattern (idiomatic usage)
- Sequential reloads see progressive edits
- Fresh allocation per call (distinct pointers across reloads, never equal to original)
- `WatchedConfigFiles` auto-tracks tagged fields (single and `[]string` chain)
- `WatchConfigFile` registration from hooks persists across reloads
- Empty-string `WatchConfigFile` is silently ignored
- `Reload[T]` with wrong T produces clear error message
- Nil `reloadFactory` produces clear \"no reload factory\" error

## Docs

- New dedicated page `docs/live-reload.md` wired into the mkdocs navbar with SIGHUP / HTTP / fsnotify / timer recipes
- `docs/advanced.md` trimmed to a short pointer to the new page
- `README.md` gets a `<details>` block with a SIGHUP example and a link to the full guide
- Wording reviewed in all three places to make clear that Reload never mutates — every call is a brand-new allocation

## Test plan
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] New `reload_test.go` covers fresh-allocation, CLI precedence, defaults, transactional error handling (malformed/missing/validation), multi-file overlay, atomic swap, sequential edits, WatchedConfigFiles auto-tracking + manual registration, type mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live configuration reload functionality, enabling long-running programs to re-read and re-validate config files without restarting; reload creates a fresh config snapshot without mutating the original
  * New methods to track which config files are being used and manually register additional paths for monitoring

* **Documentation**
  * Added comprehensive live reload guide with implementation examples (SIGHUP, HTTP endpoint, fsnotify, periodic timers)
  * Documented reload semantics, error handling, and atomic pointer pattern for safe config swaps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->