### PR TITLE
feat: support uint/uint8/uint16/uint32/uint64 and int8/int16 fields

### DIFF
--- a/pkg/boa/type_handler.go
+++ b/pkg/boa/type_handler.go
@@ -1,6 +1,7 @@
 package boa
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -181,6 +182,138 @@ func registerBuiltinTypes() {
 		},
 		parse: func(name, strVal string) (any, error) {
 			v, err := strconv.ParseInt(strVal, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			return &v, nil
+		},
+	}
+
+	kindHandlers[reflect.Int8] = &typeHandler{
+		baseType: reflect.TypeOf(int8(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := int8(0)
+			if defaultVal != nil {
+				def = int8(reflect.ValueOf(defaultVal).Elem().Int())
+			}
+			return cmd.Flags().Int8P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseInt(strVal, 10, 8)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := int8(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Int16] = &typeHandler{
+		baseType: reflect.TypeOf(int16(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := int16(0)
+			if defaultVal != nil {
+				def = int16(reflect.ValueOf(defaultVal).Elem().Int())
+			}
+			return cmd.Flags().Int16P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseInt(strVal, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := int16(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Uint] = &typeHandler{
+		baseType: reflect.TypeOf(uint(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := uint(0)
+			if defaultVal != nil {
+				def = uint(reflect.ValueOf(defaultVal).Elem().Uint())
+			}
+			return cmd.Flags().UintP(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseUint(strVal, 10, 0)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := uint(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Uint8] = &typeHandler{
+		baseType: reflect.TypeOf(uint8(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := uint8(0)
+			if defaultVal != nil {
+				def = uint8(reflect.ValueOf(defaultVal).Elem().Uint())
+			}
+			return cmd.Flags().Uint8P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseUint(strVal, 10, 8)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := uint8(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Uint16] = &typeHandler{
+		baseType: reflect.TypeOf(uint16(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := uint16(0)
+			if defaultVal != nil {
+				def = uint16(reflect.ValueOf(defaultVal).Elem().Uint())
+			}
+			return cmd.Flags().Uint16P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseUint(strVal, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := uint16(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Uint32] = &typeHandler{
+		baseType: reflect.TypeOf(uint32(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := uint32(0)
+			if defaultVal != nil {
+				def = uint32(reflect.ValueOf(defaultVal).Elem().Uint())
+			}
+			return cmd.Flags().Uint32P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseUint(strVal, 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
+			}
+			result := uint32(v)
+			return &result, nil
+		},
+	}
+
+	kindHandlers[reflect.Uint64] = &typeHandler{
+		baseType: reflect.TypeOf(uint64(0)),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			def := uint64(0)
+			if defaultVal != nil {
+				def = reflect.ValueOf(defaultVal).Elem().Uint()
+			}
+			return cmd.Flags().Uint64P(name, short, def, descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			v, err := strconv.ParseUint(strVal, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("invalid value for param %s: %s", name, err.Error())
 			}
@@ -512,6 +645,46 @@ func registerBuiltinTypes() {
 		},
 	}
 
+	sliceKindHandlers[reflect.Uint] = &typeHandler{
+		baseType: reflect.SliceOf(reflect.TypeOf(uint(0))),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			return cmd.Flags().UintSliceP(name, short, toTypedSlice[uint](derefSliceDefault(defaultVal)), descr)
+		},
+		parse: func(name, strVal string) (any, error) {
+			return parseSliceWith(strVal, func(s string) (uint, error) {
+				v, err := strconv.ParseUint(s, 10, 0)
+				return uint(v), err
+			})
+		},
+	}
+
+	// pflag has no native Uint8/Uint16/Uint32/Uint64/Int8/Int16 slice flags.
+	// For these, register a typed pflag.Value via Var() — outward shape matches
+	// Int32SliceP / Int64SliceP (proper element type in --help, no string round-trip).
+	sliceKindHandlers[reflect.Int8] = makeIntSliceFallbackHandler(reflect.TypeOf(int8(0)), "int8Slice",
+		func(s string) (int8, error) { v, err := strconv.ParseInt(s, 10, 8); return int8(v), err },
+		func(v int8) string { return strconv.FormatInt(int64(v), 10) })
+
+	sliceKindHandlers[reflect.Int16] = makeIntSliceFallbackHandler(reflect.TypeOf(int16(0)), "int16Slice",
+		func(s string) (int16, error) { v, err := strconv.ParseInt(s, 10, 16); return int16(v), err },
+		func(v int16) string { return strconv.FormatInt(int64(v), 10) })
+
+	sliceKindHandlers[reflect.Uint8] = makeIntSliceFallbackHandler(reflect.TypeOf(uint8(0)), "uint8Slice",
+		func(s string) (uint8, error) { v, err := strconv.ParseUint(s, 10, 8); return uint8(v), err },
+		func(v uint8) string { return strconv.FormatUint(uint64(v), 10) })
+
+	sliceKindHandlers[reflect.Uint16] = makeIntSliceFallbackHandler(reflect.TypeOf(uint16(0)), "uint16Slice",
+		func(s string) (uint16, error) { v, err := strconv.ParseUint(s, 10, 16); return uint16(v), err },
+		func(v uint16) string { return strconv.FormatUint(uint64(v), 10) })
+
+	sliceKindHandlers[reflect.Uint32] = makeIntSliceFallbackHandler(reflect.TypeOf(uint32(0)), "uint32Slice",
+		func(s string) (uint32, error) { v, err := strconv.ParseUint(s, 10, 32); return uint32(v), err },
+		func(v uint32) string { return strconv.FormatUint(uint64(v), 10) })
+
+	sliceKindHandlers[reflect.Uint64] = makeIntSliceFallbackHandler(reflect.TypeOf(uint64(0)), "uint64Slice",
+		func(s string) (uint64, error) { return strconv.ParseUint(s, 10, 64) },
+		func(v uint64) string { return strconv.FormatUint(v, 10) })
+
 	sliceKindHandlers[reflect.Float32] = &typeHandler{
 		baseType: reflect.SliceOf(reflect.TypeOf(float32(0))),
 		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
@@ -739,6 +912,125 @@ func buildMapParse(mapType, valType reflect.Type, valHandler *typeHandler) func(
 		ptr.Elem().Set(result)
 		return ptr.Interface(), nil
 	}
+}
+
+// typedIntSliceValue is a pflag.Value / pflag.SliceValue implementation for integer
+// slice types pflag has no native slice flag for (uint8, uint16, uint32, uint64,
+// int8, int16). Same outward behavior as Int32SliceP / Int64SliceP: comma-split,
+// repeated-flag, CSV-with-quotes — pflag handles all of that via Set().
+type typedIntSliceValue[T any] struct {
+	value      *[]T
+	changed    bool
+	parseElem  func(string) (T, error)
+	formatElem func(T) string
+	typeName   string
+}
+
+func (s *typedIntSliceValue[T]) Set(val string) error {
+	parts, err := readAsCSV(val)
+	if err != nil {
+		return err
+	}
+	parsed := make([]T, 0, len(parts))
+	for _, p := range parts {
+		v, err := s.parseElem(p)
+		if err != nil {
+			return err
+		}
+		parsed = append(parsed, v)
+	}
+	if !s.changed {
+		*s.value = parsed
+	} else {
+		*s.value = append(*s.value, parsed...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *typedIntSliceValue[T]) Type() string { return s.typeName }
+
+func (s *typedIntSliceValue[T]) String() string {
+	parts := make([]string, len(*s.value))
+	for i, v := range *s.value {
+		parts[i] = s.formatElem(v)
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}
+
+func (s *typedIntSliceValue[T]) Append(val string) error {
+	v, err := s.parseElem(val)
+	if err != nil {
+		return err
+	}
+	*s.value = append(*s.value, v)
+	return nil
+}
+
+func (s *typedIntSliceValue[T]) Replace(vals []string) error {
+	parsed := make([]T, 0, len(vals))
+	for _, str := range vals {
+		v, err := s.parseElem(str)
+		if err != nil {
+			return err
+		}
+		parsed = append(parsed, v)
+	}
+	*s.value = parsed
+	return nil
+}
+
+func (s *typedIntSliceValue[T]) GetSlice() []string {
+	parts := make([]string, len(*s.value))
+	for i, v := range *s.value {
+		parts[i] = s.formatElem(v)
+	}
+	return parts
+}
+
+// makeIntSliceFallbackHandler builds a slice handler for integer types pflag has no
+// native slice flag for. Uses Var() with a typedIntSliceValue so the resulting flag
+// is a proper typed slice (same shape as Int32SliceP) — no string round-trip, no
+// convert function needed.
+func makeIntSliceFallbackHandler[T any](
+	elemType reflect.Type,
+	typeName string,
+	parseElem func(string) (T, error),
+	formatElem func(T) string,
+) *typeHandler {
+	return &typeHandler{
+		baseType: reflect.SliceOf(elemType),
+		bindFlag: func(cmd *cobra.Command, name, short, descr string, defaultVal any) any {
+			storage := new([]T)
+			if defaultVal != nil {
+				if typed := toTypedSlice[T](derefSliceDefault(defaultVal)); typed != nil {
+					*storage = typed
+				}
+			}
+			v := &typedIntSliceValue[T]{
+				value:      storage,
+				parseElem:  parseElem,
+				formatElem: formatElem,
+				typeName:   typeName,
+			}
+			cmd.Flags().VarP(v, name, short, descr)
+			return storage
+		},
+		parse: func(name, strVal string) (any, error) {
+			return parseSliceWith(strVal, parseElem)
+		},
+	}
+}
+
+// readAsCSV parses one value pflag receives from the command line into individual
+// elements, using csv rules so quoted commas survive (matches pflag's own
+// stringSliceValue behavior).
+func readAsCSV(val string) ([]string, error) {
+	if val == "" {
+		return nil, nil
+	}
+	stringReader := csv.NewReader(strings.NewReader(val))
+	return stringReader.Read()
 }
 
 // derefSliceDefault dereferences a defaultVal pointer (e.g., *[]string → []string) for slice handlers.

--- a/pkg/boa/uint_int_small_test.go
+++ b/pkg/boa/uint_int_small_test.go
@@ -1,0 +1,432 @@
+package boa
+
+import (
+	"math"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// Tests for unsigned integer types (uint, uint8, uint16, uint32, uint64) and the
+// small signed integer types (int8, int16). Prior to support being added these
+// fields were silently dropped by isSupportedType, so the corresponding CLI flag
+// was never registered — every test below would fail with "unknown flag: --..."
+// or with the field staying at its zero value.
+
+// ==================== uint ====================
+
+func TestUint_CLI(t *testing.T) {
+	type P struct {
+		Count uint `descr:"count"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Count != 42 {
+				t.Errorf("expected 42 got %d", p.Count)
+			}
+		},
+	}).RunArgsE([]string{"--count", "42"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestUint_Default(t *testing.T) {
+	type P struct {
+		Count uint `descr:"count" default:"7" optional:"true"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Count != 7 {
+				t.Errorf("expected 7 got %d", p.Count)
+			}
+		},
+	}).RunArgsE([]string{}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== uint8 ====================
+
+func TestUint8_CLI(t *testing.T) {
+	type P struct {
+		Byte uint8 `descr:"byte"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Byte != 255 {
+				t.Errorf("expected 255 got %d", p.Byte)
+			}
+		},
+	}).RunArgsE([]string{"--byte", "255"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestUint8_OutOfRange(t *testing.T) {
+	type P struct {
+		Byte uint8 `descr:"byte"`
+	}
+	err := (CmdT[P]{
+		Use:     "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {},
+	}).RunArgsE([]string{"--byte", "256"})
+	if err == nil {
+		t.Fatal("expected error for value out of uint8 range")
+	}
+}
+
+// ==================== uint16 ====================
+
+func TestUint16_CLI(t *testing.T) {
+	type P struct {
+		Port uint16 `descr:"port"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Port != 65535 {
+				t.Errorf("expected 65535 got %d", p.Port)
+			}
+		},
+	}).RunArgsE([]string{"--port", "65535"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== uint32 ====================
+
+func TestUint32_CLI(t *testing.T) {
+	type P struct {
+		ID uint32 `descr:"id"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.ID != math.MaxUint32 {
+				t.Errorf("expected %d got %d", uint32(math.MaxUint32), p.ID)
+			}
+		},
+	}).RunArgsE([]string{"--id", "4294967295"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== uint64 ====================
+
+func TestUint64_CLI(t *testing.T) {
+	type P struct {
+		Port uint64 `descr:"port"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Port != 8080 {
+				t.Errorf("expected 8080 got %d", p.Port)
+			}
+		},
+	}).RunArgsE([]string{"--port", "8080"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestUint64_LargeValue(t *testing.T) {
+	type P struct {
+		N uint64 `descr:"n"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.N != math.MaxUint64 {
+				t.Errorf("expected MaxUint64 got %d", p.N)
+			}
+		},
+	}).RunArgsE([]string{"--n", "18446744073709551615"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestUint64_EnvVar(t *testing.T) {
+	type P struct {
+		N uint64 `descr:"n" env:"TEST_UINT64_N"`
+	}
+	t.Setenv("TEST_UINT64_N", "12345")
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.N != 12345 {
+				t.Errorf("expected 12345 got %d", p.N)
+			}
+		},
+	}).RunArgsE([]string{}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== int8 ====================
+
+func TestInt8_CLI(t *testing.T) {
+	type P struct {
+		N int8 `descr:"n"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.N != -128 {
+				t.Errorf("expected -128 got %d", p.N)
+			}
+		},
+	}).RunArgsE([]string{"--n", "-128"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== int16 ====================
+
+func TestInt16_CLI(t *testing.T) {
+	type P struct {
+		N int16 `descr:"n"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.N != 32767 {
+				t.Errorf("expected 32767 got %d", p.N)
+			}
+		},
+	}).RunArgsE([]string{"--n", "32767"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== slice variants ====================
+
+func TestSliceUint_CLI(t *testing.T) {
+	type P struct {
+		Vals []uint `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 3 || p.Vals[0] != 1 || p.Vals[1] != 2 || p.Vals[2] != 3 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "1", "--vals", "2", "--vals", "3"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceUint8_CLI(t *testing.T) {
+	type P struct {
+		Bytes []uint8 `descr:"bytes"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Bytes) != 2 || p.Bytes[0] != 0 || p.Bytes[1] != 255 {
+				t.Errorf("unexpected bytes: %v", p.Bytes)
+			}
+		},
+	}).RunArgsE([]string{"--bytes", "0", "--bytes", "255"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceUint16_CLI(t *testing.T) {
+	type P struct {
+		Ports []uint16 `descr:"ports"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Ports) != 2 || p.Ports[0] != 80 || p.Ports[1] != 65535 {
+				t.Errorf("unexpected ports: %v", p.Ports)
+			}
+		},
+	}).RunArgsE([]string{"--ports", "80", "--ports", "65535"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceUint32_CLI(t *testing.T) {
+	type P struct {
+		Vals []uint32 `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 2 || p.Vals[0] != 1 || p.Vals[1] != math.MaxUint32 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "1", "--vals", "4294967295"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceUint64_CLI(t *testing.T) {
+	type P struct {
+		Vals []uint64 `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 2 || p.Vals[0] != 1 || p.Vals[1] != math.MaxUint64 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "1", "--vals", "18446744073709551615"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceInt8_CLI(t *testing.T) {
+	type P struct {
+		Vals []int8 `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 2 || p.Vals[0] != -128 || p.Vals[1] != 127 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "-128", "--vals", "127"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+func TestSliceInt16_CLI(t *testing.T) {
+	type P struct {
+		Vals []int16 `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 2 || p.Vals[0] != -32768 || p.Vals[1] != 32767 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "-32768", "--vals", "32767"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// ==================== type aliases ====================
+
+type Port uint16
+type UserID uint64
+
+type CustomUintParams struct {
+	Port   Port   `descr:"port"`
+	UserID UserID `descr:"user id"`
+}
+
+func TestCustomUintTypeAliases(t *testing.T) {
+	wasRun := false
+	if err := (CmdT[CustomUintParams]{
+		Use: "test",
+		RunFunc: func(p *CustomUintParams, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if p.Port != 8443 {
+				t.Errorf("expected 8443 got %d", p.Port)
+			}
+			if p.UserID != 999999 {
+				t.Errorf("expected 999999 got %d", p.UserID)
+			}
+		},
+	}).RunArgsE([]string{"--port", "8443", "--user-id", "999999"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}

--- a/pkg/boa/uint_int_small_test.go
+++ b/pkg/boa/uint_int_small_test.go
@@ -430,3 +430,97 @@ func TestCustomUintTypeAliases(t *testing.T) {
 		t.Fatal("run func was not called")
 	}
 }
+
+// ==================== slice: CSV / env / default coverage ====================
+
+// Locks in typedIntSliceValue.Set's CSV-split path when a single --flag carries
+// multiple comma-separated values (the repeated-flag cases above only hit the
+// "first value" branch).
+func TestSliceUint16_CSVSingleFlag(t *testing.T) {
+	type P struct {
+		Vals []uint16 `descr:"vals"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 3 || p.Vals[0] != 1 || p.Vals[1] != 2 || p.Vals[2] != 3 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{"--vals", "1,2,3"}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// Locks in the parseSliceWith path used by env-var ingestion for slice types
+// without a native pflag slice flag.
+func TestSliceUint16_EnvVar(t *testing.T) {
+	type P struct {
+		Vals []uint16 `descr:"vals" env:"TEST_UINT16_VALS"`
+	}
+	t.Setenv("TEST_UINT16_VALS", "10,20,30")
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 3 || p.Vals[0] != 10 || p.Vals[1] != 20 || p.Vals[2] != 30 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// Locks in the default-tag path through parseSliceWith.
+func TestSliceUint8_Default(t *testing.T) {
+	type P struct {
+		Bytes []uint8 `descr:"bytes" default:"0,127,255" optional:"true"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Bytes) != 3 || p.Bytes[0] != 0 || p.Bytes[1] != 127 || p.Bytes[2] != 255 {
+				t.Errorf("unexpected bytes: %v", p.Bytes)
+			}
+		},
+	}).RunArgsE([]string{}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}
+
+// Same as above but with the bracketed [a,b,c] form parseSliceWith also accepts.
+func TestSliceInt16_DefaultBracketed(t *testing.T) {
+	type P struct {
+		Vals []int16 `descr:"vals" default:"[-1,0,1]" optional:"true"`
+	}
+	wasRun := false
+	if err := (CmdT[P]{
+		Use: "test",
+		RunFunc: func(p *P, cmd *cobra.Command, args []string) {
+			wasRun = true
+			if len(p.Vals) != 3 || p.Vals[0] != -1 || p.Vals[1] != 0 || p.Vals[2] != 1 {
+				t.Errorf("unexpected vals: %v", p.Vals)
+			}
+		},
+	}).RunArgsE([]string{}); err != nil {
+		t.Fatalf("RunArgsE: %v", err)
+	}
+	if !wasRun {
+		t.Fatal("run func was not called")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds CLI / env / default support for `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `int8`, `int16` and their slice variants
- Previously these field types were silently dropped — `isSupportedType` returned false because `kindHandlers` had no entries for them, so the corresponding flag was never registered and the user saw `WARN field X is not a type that is interpretable as a boa.Param. It will be ignored`
- Slice variants additionally fell through to the JSON fallback, which couldn't parse repeated `--flag value` syntax

## Implementation

- **Scalars**: native pflag methods (`UintP`, `Uint8P`, …, `Int16P`)
- **`[]uint`**: native `UintSliceP`
- **`[]uint8/16/32/64`, `[]int8/16`**: pflag has no native slice flag for these. Registered via `VarP` with a typed `pflag.Value` (`typedIntSliceValue[T]`) — same outward shape as `Int32SliceP` (proper element type in `--help`, comma-split + repeated-flag, no string round-trip, no `convert` function needed)

## Help-text shape (illustrative)

```
-i, --i32 int32          signed 32-bit (required)
-u, --u32 uint32         unsigned 32-bit (required)
    --u32s uint32Slice   unsigned 32-bit slice (required) (default [])
    --u8s uint8Slice     unsigned 8-bit slice (required) (default [])
    --i8s int8Slice      signed 8-bit slice (required) (default [])
```

The custom `pflag.Value` instances render an element-typed name (e.g. `uint32Slice`) just like the native `int32Slice`.

## Test plan

- [x] 17 new tests in `pkg/boa/uint_int_small_test.go` cover scalars, slices, env vars, defaults, range overflow, and type aliases (`type Port uint16`)
- [x] `go test ./...` — full suite green, no regressions
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended CLI flag support for additional integer types (int8, int16, uint8, uint16, uint32, uint64).
  * Added slice support for integer types with comma-separated value parsing and quote-aware handling.
  * Improved validation and error handling for out-of-range integer values.
  * Enhanced environment variable binding capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->