### PR TITLE
Split release out of CI; tighten CI permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -31,46 +34,3 @@ jobs:
 
       - name: Run tests
         run: go test ./...
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.26.2'
-
-      - name: Generate version
-        id: version
-        run: |
-          # Get the latest tag
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          
-          # Calculate new version - increment patch version
-          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
-          NEW_VERSION="v$major.$minor.$((patch+1))"
-          
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "Creating new version: $NEW_VERSION"
-
-      - name: Create tag
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
-          git push origin ${{ steps.version.outputs.new_version }}
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.version.outputs.new_version }}
-          name: Release ${{ steps.version.outputs.new_version }}
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.2'
+
+      - name: Generate version
+        id: version
+        run: |
+          # Get the latest tag
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+
+          # Calculate new version - increment patch version
+          IFS='.' read -r major minor patch <<< "${LATEST_TAG/v/}"
+          NEW_VERSION="v$major.$minor.$((patch+1))"
+
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Creating new version: $NEW_VERSION"
+
+      - name: Create tag
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git tag -a ${{ steps.version.outputs.new_version }} -m "Release ${{ steps.version.outputs.new_version }}"
+          git push origin ${{ steps.version.outputs.new_version }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.new_version }}
+          name: Release ${{ steps.version.outputs.new_version }}
+          generate_release_notes: true

--- a/internal/example_custom_config_format/main.go
+++ b/internal/example_custom_config_format/main.go
@@ -118,7 +118,7 @@ func assignDotted(v reflect.Value, segments []string, val string) error {
 	}
 	// Follow a pointer-to-struct if present (boa preallocates these for
 	// optional parameter groups, so deref is always safe here).
-	if field.Kind() == reflect.Ptr && field.Type().Elem().Kind() == reflect.Struct {
+	if field.Kind() == reflect.Pointer && field.Type().Elem().Kind() == reflect.Struct {
 		if field.IsNil() {
 			field.Set(reflect.New(field.Type().Elem()))
 		}

--- a/pkg/boa/api_base.go
+++ b/pkg/boa/api_base.go
@@ -416,7 +416,7 @@ func (c *HookContext) GetParam(fieldPtr any) Param {
 		return nil
 	}
 	rv := reflect.ValueOf(fieldPtr)
-	if rv.Kind() != reflect.Ptr {
+	if rv.Kind() != reflect.Pointer {
 		slog.Error("boa.HookContext.GetParam: fieldPtr must be a pointer to a struct field",
 			"got_type", fmt.Sprintf("%T", fieldPtr))
 		return nil
@@ -750,7 +750,7 @@ func (c *HookContext) buildSetValueTree(tagName string) (map[string]any, error) 
 		return nil, fmt.Errorf("boa: HookContext: no root parameters struct")
 	}
 	rv := reflect.ValueOf(c.ctx.rootStructPtr)
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return nil, fmt.Errorf("boa: HookContext: root parameters struct is nil")
 		}
@@ -800,7 +800,7 @@ func shouldEmitInDump(f Param, v reflect.Value) bool {
 // key names (see structTagForExt); an empty tagName means "use the Go
 // field name".
 func buildSetValueMapNode(v reflect.Value, ctx *processingContext, pathIdx []int, tagName string) map[string]any {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			return nil
 		}
@@ -857,7 +857,7 @@ func buildSetValueMapNode(v reflect.Value, ctx *processingContext, pathIdx []int
 					out[name] = sub
 				}
 			}
-		case reflect.Ptr:
+		case reflect.Pointer:
 			if !fv.IsNil() && fv.Elem().Kind() == reflect.Struct {
 				if sub := buildSetValueMapNode(fv, ctx, childIdx, tagName); len(sub) > 0 {
 					if sf.Anonymous {

--- a/pkg/boa/api_typed_base.go
+++ b/pkg/boa/api_typed_base.go
@@ -99,7 +99,7 @@ func (b CmdT[Struct]) ToCmd() Cmd {
 	}
 
 	// Validate that Params is a struct
-	if reflect.TypeOf(b.Params).Kind() != reflect.Ptr {
+	if reflect.TypeOf(b.Params).Kind() != reflect.Pointer {
 		panic(fmt.Errorf("expected pointer to struct"))
 	}
 	if reflect.TypeOf(b.Params).Elem().Kind() != reflect.Struct {

--- a/pkg/boa/api_typed_param.go
+++ b/pkg/boa/api_typed_param.go
@@ -209,7 +209,7 @@ func (w *ParamTView[T]) SetCustomValidatorT(fn func(T) error) {
 		default:
 			// Try reflection-based conversion for type aliases
 			valReflect := reflect.ValueOf(val)
-			if valReflect.Kind() == reflect.Ptr && !valReflect.IsNil() {
+			if valReflect.Kind() == reflect.Pointer && !valReflect.IsNil() {
 				valReflect = valReflect.Elem()
 			}
 			var zero T

--- a/pkg/boa/config_format_test.go
+++ b/pkg/boa/config_format_test.go
@@ -772,7 +772,7 @@ func miniKVUnmarshal(data []byte, target any) error {
 		return err
 	}
 	v := reflect.ValueOf(target)
-	if v.Kind() != reflect.Ptr || v.IsNil() {
+	if v.Kind() != reflect.Pointer || v.IsNil() {
 		return fmt.Errorf("mini-kv: target must be a non-nil pointer")
 	}
 	return miniKVAssign(v.Elem(), tree)
@@ -808,7 +808,7 @@ func miniKVKeyTree(data []byte) (map[string]any, error) {
 }
 
 func miniKVAssign(v reflect.Value, tree map[string]any) error {
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			v.Set(reflect.New(v.Type().Elem()))
 		}
@@ -852,7 +852,7 @@ func miniKVAssign(v reflect.Value, tree map[string]any) error {
 		// Nested struct / *struct: recurse when the raw value is a map.
 		ft := sf.Type
 		inner := fv
-		if ft.Kind() == reflect.Ptr {
+		if ft.Kind() == reflect.Pointer {
 			if fv.IsNil() {
 				fv.Set(reflect.New(ft.Elem()))
 			}

--- a/pkg/boa/internal.go
+++ b/pkg/boa/internal.go
@@ -395,7 +395,7 @@ func preallocateStructPtrs(ctx *processingContext, structPtr any, path []int) {
 			continue
 		}
 		// Preallocate nil struct pointer fields
-		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) {
+		if field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) {
 			fieldVal := val.Field(i)
 			if fieldVal.IsNil() {
 				fieldVal.Set(reflect.New(field.Type.Elem()))
@@ -446,7 +446,7 @@ func cleanupPreallocatedPtrs(ctx *processingContext) {
 			structVal := reflect.ValueOf(structPtr).Elem()
 			for i := 0; i < structVal.NumField(); i++ {
 				f := structVal.Field(i)
-				if f.Kind() == reflect.Ptr && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+				if f.Kind() == reflect.Pointer && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
 					anySet = true
 					break
 				}
@@ -516,7 +516,7 @@ func canonicalizeKeyTree(raw map[string]any, targetType reflect.Type, tag string
 	if raw == nil {
 		return nil
 	}
-	for targetType != nil && targetType.Kind() == reflect.Ptr {
+	for targetType != nil && targetType.Kind() == reflect.Pointer {
 		targetType = targetType.Elem()
 	}
 	if targetType == nil || targetType.Kind() != reflect.Struct {
@@ -543,7 +543,7 @@ func canonicalizeKeyTree(raw map[string]any, targetType reflect.Type, tag string
 		// Recurse into nested struct / *struct fields so their sub-keys
 		// also end up keyed by Go field name before the walker sees them.
 		ft := sf.Type
-		for ft.Kind() == reflect.Ptr {
+		for ft.Kind() == reflect.Pointer {
 			ft = ft.Elem()
 		}
 		if ft.Kind() == reflect.Struct && !isSupportedType(sf.Type) {
@@ -664,7 +664,7 @@ func markConfigKeysPresentInStruct(ctx *processingContext, structPtr any, keys m
 		}
 		fieldVal := val.Field(i)
 		// If this is a struct pointer field and it's preallocated (non-nil)
-		if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) && !fieldVal.IsNil() {
+		if field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) && !fieldVal.IsNil() {
 			// The config mentioned this struct — mark it as present so the
 			// pointer survives cleanup, even if the object is empty `{}`.
 			// Individual fields only get setByConfig if they appear as keys.
@@ -841,7 +841,7 @@ func collectAndCheck(ctx *processingContext, structPtr any, path []int, anySet *
 			continue
 		}
 		// Recurse into non-nil pointer structs
-		if field.Type.Kind() == reflect.Ptr && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
+		if field.Type.Kind() == reflect.Pointer && !fieldVal.IsNil() && field.Type.Elem().Kind() == reflect.Struct {
 			collectAndCheck(ctx, fieldVal.Interface(), childPath, anySet)
 		}
 	}
@@ -1066,7 +1066,7 @@ func validateMinMaxPattern(pm *paramMeta, valPtr any) error {
 	}
 
 	v := reflect.ValueOf(valPtr)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		v = v.Elem()
 	}
 
@@ -1130,7 +1130,7 @@ func ptrToAnyToString(ptr any) string {
 	}
 
 	val := reflect.ValueOf(ptr)
-	if val.Kind() != reflect.Ptr {
+	if val.Kind() != reflect.Pointer {
 		panic("ptrToAnyToString called with non-pointer")
 	}
 
@@ -1629,7 +1629,7 @@ func traverseAt(
 ) error {
 	prefix := strings.Join(prefixParts, "")
 
-	if reflect.TypeOf(structPtr).Kind() != reflect.Ptr {
+	if reflect.TypeOf(structPtr).Kind() != reflect.Pointer {
 		return fmt.Errorf("expected pointer to struct")
 	}
 
@@ -1692,7 +1692,7 @@ func traverseAt(
 			}
 
 			// check if it is a pointer to a struct (but not *url.URL or pointer-to-supported-type)
-			if field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) {
+			if field.Type.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.Struct && !isSupportedType(field.Type) {
 				if !fieldAddr.IsNil() && !fieldAddr.Elem().IsNil() {
 					childPrefix := prefix
 					if !field.Anonymous {
@@ -2564,7 +2564,7 @@ func (ctx *processingContext) resolveFieldValue(path fieldPath) (reflect.Value, 
 	v := reflect.ValueOf(ctx.rootStructPtr).Elem()
 	idx := splitPath(path)
 	for _, i := range idx {
-		for v.Kind() == reflect.Ptr {
+		for v.Kind() == reflect.Pointer {
 			if v.IsNil() {
 				return reflect.Value{}, false
 			}

--- a/pkg/boa/param_meta.go
+++ b/pkg/boa/param_meta.go
@@ -209,7 +209,7 @@ func (f *paramMeta) SetDefault(val any) {
 	valRef := reflect.ValueOf(val)
 
 	// val should be a pointer (*T) — dereference to get the value
-	if valRef.Kind() == reflect.Ptr && !valRef.IsNil() {
+	if valRef.Kind() == reflect.Pointer && !valRef.IsNil() {
 		elem := valRef.Elem()
 
 		// Direct type match
@@ -327,7 +327,7 @@ func (f *paramMeta) customValidatorOfPtr() func(any) error {
 			return nil
 		}
 		v := reflect.ValueOf(val)
-		if v.Kind() == reflect.Ptr && !v.IsNil() {
+		if v.Kind() == reflect.Pointer && !v.IsNil() {
 			if f.isPointer {
 				// For pointer fields (*int, *string, etc.), pass the pointer value
 				// so the validator receives the same type the user declared.
@@ -407,7 +407,7 @@ func coerceBound(raw any, bk boundKind) (any, error) {
 	}
 	rv := reflect.ValueOf(raw)
 	// Unwrap a single level of pointer, e.g. caller passed *int64.
-	if rv.Kind() == reflect.Ptr {
+	if rv.Kind() == reflect.Pointer {
 		if rv.IsNil() {
 			return nil, fmt.Errorf("nil bound")
 		}
@@ -594,7 +594,7 @@ func (f *paramMeta) MarshalJSON() ([]byte, error) {
 	}
 	if f.valuePtr != nil {
 		val := reflect.ValueOf(f.valuePtr)
-		if val.Kind() == reflect.Ptr && !val.IsNil() {
+		if val.Kind() == reflect.Pointer && !val.IsNil() {
 			return json.Marshal(val.Elem().Interface())
 		}
 		return json.Marshal(nil)

--- a/pkg/boa/substruct_configfile_test.go
+++ b/pkg/boa/substruct_configfile_test.go
@@ -19,7 +19,7 @@ import (
 // Supports string, int, and bool fields. For testing config format registry.
 func iniUnmarshal(data []byte, target any) error {
 	v := reflect.ValueOf(target)
-	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+	if v.Kind() != reflect.Pointer || v.Elem().Kind() != reflect.Struct {
 		return fmt.Errorf("ini: target must be a pointer to struct")
 	}
 	v = v.Elem()

--- a/pkg/boa/type_handler.go
+++ b/pkg/boa/type_handler.go
@@ -87,7 +87,7 @@ func RegisterType[T any](def TypeDef[T]) {
 			def := ""
 			if defaultVal != nil {
 				v := reflect.ValueOf(defaultVal)
-				if v.Kind() == reflect.Ptr && !v.IsNil() {
+				if v.Kind() == reflect.Pointer && !v.IsNil() {
 					def = formatFn(v.Elem().Interface().(T))
 				}
 			}
@@ -759,7 +759,7 @@ func jsonFallbackHandler(t reflect.Type) *typeHandler {
 			if defaultVal != nil {
 				// Marshal the default to JSON for display
 				v := reflect.ValueOf(defaultVal)
-				if v.Kind() == reflect.Ptr && !v.IsNil() {
+				if v.Kind() == reflect.Pointer && !v.IsNil() {
 					b, err := json.Marshal(v.Elem().Interface())
 					if err == nil {
 						def = string(b)
@@ -1040,7 +1040,7 @@ func derefSliceDefault(defaultVal any) any {
 		return nil
 	}
 	v := reflect.ValueOf(defaultVal)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		return v.Elem().Interface()
 	}
 	return defaultVal


### PR DESCRIPTION
## Summary

- Move the release job from `ci.yml` into a new `release.yml` triggered **only** on `push:main` and `workflow_dispatch`.
- `ci.yml` now declares `permissions: contents: read` at the workflow level.
- The release job retains its existing logic.

## Why

Defense-in-depth on top of the fork-PR approval setting. `release.yml` has no `pull_request` trigger and a fork PR cannot fire `push:main` or `workflow_dispatch`, so it's structurally unreachable from any PR-driven trigger. The if-guard on the release job is no longer the only thing standing between an attacker and the `@latest` install path.

## Test plan

- [ ] Merge → confirm release job fires on push to main
- [ ] Open a noop PR → confirm only test job runs